### PR TITLE
bindwheel with settingtab

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2001,6 +2001,8 @@ if(CLIENT)
     components/background.h
     components/binds.cpp
     components/binds.h
+    components/bindwheel.cpp
+    components/bindwheel.h
     components/broadcast.cpp
     components/broadcast.h
     components/camera.cpp

--- a/src/engine/config.h
+++ b/src/engine/config.h
@@ -19,6 +19,7 @@ public:
 	virtual class CConfig *Values() = 0;
 
 	virtual void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) = 0;
+	virtual void RegisterTCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) = 0;
 
 	virtual void WriteLine(const char *pLine) = 0;
 };

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -17,6 +17,7 @@ CConfigManager::CConfigManager()
 	m_pStorage = 0;
 	m_ConfigFile = 0;
 	m_NumCallbacks = 0;
+	m_NumTCallbacks = 0;
 	m_Failed = false;
 }
 

--- a/src/engine/shared/config.cpp
+++ b/src/engine/shared/config.cpp
@@ -180,6 +180,10 @@ bool CConfigManager::TSave()
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR
 
+	for(int i = 0; i < m_NumTCallbacks; i++)
+		m_aTCallbacks[i].m_pfnFunc(this, m_aTCallbacks[i].m_pUserData);
+
+
 	if(io_sync(m_ConfigFile) != 0)
 	{
 		m_Failed = true;
@@ -212,6 +216,15 @@ void CConfigManager::RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData)
 	m_aCallbacks[m_NumCallbacks].m_pUserData = pUserData;
 	m_NumCallbacks++;
 }
+
+void CConfigManager::RegisterTCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData)
+{
+	dbg_assert(m_NumTCallbacks < MAX_CALLBACKS, "too many tater config callbacks");
+	m_aTCallbacks[m_NumTCallbacks].m_pfnFunc = pfnFunc;
+	m_aTCallbacks[m_NumTCallbacks].m_pUserData = pUserData;
+	m_NumTCallbacks++;
+}
+
 
 void CConfigManager::WriteLine(const char *pLine)
 {

--- a/src/engine/shared/config.h
+++ b/src/engine/shared/config.h
@@ -62,7 +62,11 @@ class CConfigManager : public IConfigManager
 	IOHANDLE m_ConfigFile;
 	bool m_Failed;
 	CCallback m_aCallbacks[MAX_CALLBACKS];
+
 	int m_NumCallbacks;
+
+	CCallback m_aTCallbacks[MAX_CALLBACKS];
+	int m_NumTCallbacks;
 
 public:
 	CConfigManager();
@@ -76,6 +80,7 @@ public:
 	CConfig *Values() override { return &g_Config; }
 
 	void RegisterCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) override;
+	void RegisterTCallback(SAVECALLBACKFUNC pfnFunc, void *pUserData) override;
 
 	void WriteLine(const char *pLine) override;
 };

--- a/src/game/client/components/binds.cpp
+++ b/src/game/client/components/binds.cpp
@@ -215,6 +215,7 @@ void CBinds::SetDefaults()
 	Bind(KEY_MOUSE_1, "+fire");
 	Bind(KEY_MOUSE_2, "+hook");
 	Bind(KEY_LSHIFT, "+emote");
+    Bind(KEY_Q, "+bindwheel");
 	Bind(KEY_RETURN, "+show_chat; chat all");
 	Bind(KEY_RIGHT, "spectate_next");
 	Bind(KEY_LEFT, "spectate_previous");

--- a/src/game/client/components/bindwheel.cpp
+++ b/src/game/client/components/bindwheel.cpp
@@ -1,0 +1,11 @@
+#include <engine/graphics.h>
+#include <engine/shared/config.h>
+
+#include <game/client/animstate.h>
+#include <game/client/render.h>
+#include <game/generated/client_data.h>
+#include <game/generated/protocol.h>
+
+#include <game/client/gameclient.h>
+
+#include "bindwheel.h"

--- a/src/game/client/components/bindwheel.cpp
+++ b/src/game/client/components/bindwheel.cpp
@@ -1,11 +1,234 @@
+/* (c) Magnus Auvinen. See licence.txt in the root of the distribution for more information. */
+/* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <engine/graphics.h>
 #include <engine/shared/config.h>
+#include <game/generated/protocol.h>
 
+#include "chat.h"
+#include "emoticon.h"
 #include <game/client/animstate.h>
 #include <game/client/render.h>
-#include <game/generated/client_data.h>
-#include <game/generated/protocol.h>
+#include <game/client/ui.h>
 
 #include <game/client/gameclient.h>
 
-#include "bindwheel.h"
+CBindWheel::CBindWheel()
+{
+	OnReset();
+}
+
+void CBindWheel::ConBindwheel(IConsole::IResult *pResult, void *pUserData)
+{
+	CBindWheel *pSelf = (CBindWheel *)pUserData;
+	if(!pSelf->m_pClient->m_Snap.m_SpecInfo.m_Active && pSelf->Client()->State() != IClient::STATE_DEMOPLAYBACK)
+		pSelf->m_Active = pResult->GetInteger(0) != 0;
+}
+
+void CBindWheel::ConBind(IConsole::IResult *pResult, void *pUserData)
+{
+	int bindpos = pResult->GetInteger(0);
+	char command[128];
+	char description[8];
+	str_format(description, sizeof(description), pResult->GetString(1));
+	str_format(command, sizeof(command), pResult->GetString(2));
+
+	CBindWheel *pThis = static_cast<CBindWheel *>(pUserData);
+	pThis->updateBinds(bindpos, description, command);
+
+}
+
+void CBindWheel::ConchainBindwheel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData)
+{
+	pfnCallback(pResult, pCallbackUserData);
+	if(pResult->NumArguments() == 3)
+	{
+		int bindpos = pResult->GetInteger(0);
+		char command[128];
+		char description[8];
+		str_format(description, sizeof(description), pResult->GetString(1));
+		str_format(command, sizeof(command), pResult->GetString(2));
+
+		CBindWheel *pThis = static_cast<CBindWheel *>(pUserData);
+		//pThis->updateBinds(bindpos, description, command);
+	
+	}
+}
+
+void CBindWheel::OnConsoleInit()
+{
+	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
+	if(pConfigManager)
+		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
+
+	Console()->Register("+bindwheel", "", CFGFLAG_CLIENT, ConBindwheel, this, "Open bindwheel selector");
+	Console()->Register("bindwheel", "i[bindwheel] s[description:128] s[command:8]", CFGFLAG_CLIENT, ConBind, this, "Edit the command");
+	Console()->Chain("bindwheel", ConchainBindwheel, this);
+
+
+
+	for(int i = 0; i < NUM_BINDWHEEL; i++)
+	{
+		if(!(str_comp(GameClient()->m_bindwheellist[i].description, "EMPTY") == 0))
+		{
+			str_format(GameClient()->m_bindwheellist[i].description, sizeof(GameClient()->m_bindwheellist[i].description), "EMPTY");
+		}
+
+		if(str_comp(GameClient()->m_bindwheellist[i].command, "") == 0)
+		{
+			str_format(GameClient()->m_bindwheellist[i].command, sizeof(GameClient()->m_bindwheellist[i].command), "");
+		}
+	}
+}
+
+void CBindWheel::OnReset()
+{
+	m_WasActive = false;
+	m_Active = false;
+	m_SelectedBind = -1;
+}
+
+void CBindWheel::OnRelease()
+{
+	m_Active = false;
+}
+
+bool CBindWheel::OnCursorMove(float x, float y, IInput::ECursorType CursorType)
+{
+	if(!m_Active)
+		return false;
+
+	UI()->ConvertMouseMove(&x, &y, CursorType);
+	m_SelectorMouse += vec2(x, y);
+	return true;
+}
+
+void CBindWheel::DrawCircle(float x, float y, float r, int Segments)
+{
+	RenderTools()->DrawCircle(x, y, r, Segments);
+}
+
+void CBindWheel::OnRender()
+{
+	if(!m_Active)
+	{
+		if(m_WasActive && m_SelectedBind != -1)
+			Binwheel(m_SelectedBind);
+		m_WasActive = false;
+		return;
+	}
+
+	if(m_pClient->m_Snap.m_SpecInfo.m_Active)
+	{
+		m_Active = false;
+		m_WasActive = false;
+		return;
+	}
+
+	m_WasActive = true;
+
+	if(length(m_SelectorMouse) > 170.0f)
+		m_SelectorMouse = normalize(m_SelectorMouse) * 170.0f;
+
+	float SelectedAngle = angle(m_SelectorMouse) + 2 * pi / 24;
+	if(SelectedAngle < 0)
+		SelectedAngle += 2 * pi;
+
+	m_SelectedBind = -1;
+	if(length(m_SelectorMouse) > 110.0f)
+		m_SelectedBind = (int)(SelectedAngle / (2 * pi) * NUM_BINDWHEEL);
+
+	CUIRect Screen = *UI()->Screen();
+
+	UI()->MapScreen();
+
+	Graphics()->BlendNormal();
+
+	Graphics()->TextureClear();
+	Graphics()->QuadsBegin();
+	Graphics()->SetColor(0, 0, 0, 0.3f);
+	DrawCircle(Screen.w / 2, Screen.h / 2, 190.0f, 64);
+	Graphics()->QuadsEnd();
+
+	Graphics()->WrapClamp();
+	for(int i = 0; i < NUM_BINDWHEEL; i++)
+	{
+		float Angle = 2 * pi * i / NUM_BINDWHEEL;
+
+		float margin = 170.0f;
+		if(!(Angle >= 0 && Angle <= 90 || Angle >= 270 && Angle <= 359))
+		{
+			margin = 120.0;
+		}
+		if(Angle > pi)
+        {
+            Angle -= 2 * pi;
+        }
+		
+		bool Selected = m_SelectedBind == i;
+
+		float Size = Selected ? 14.0 : 12.0f;
+
+		float NudgeX = margin * cosf(Angle);
+		float NudgeY = 150.0f * sinf(Angle);
+
+		char aBuf[8];
+		str_format(aBuf, sizeof(aBuf), GameClient()->m_bindwheellist[i].description);
+		TextRender()->Text(0, Screen.w / 2 + NudgeX, Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
+	}
+	Graphics()->WrapNormal();
+
+	if(GameClient()->m_GameInfo.m_AllowEyeWheel && g_Config.m_ClEyeWheel)
+	{
+		Graphics()->TextureClear();
+		Graphics()->QuadsBegin();
+		Graphics()->SetColor(1.0, 1.0, 1.0, 0.3f);
+		DrawCircle(Screen.w / 2, Screen.h / 2, 100.0f, 64);
+		Graphics()->QuadsEnd();
+
+		CTeeRenderInfo *pTeeInfo = &m_pClient->m_aClients[m_pClient->m_aLocalIDs[g_Config.m_ClDummy]].m_RenderInfo;
+
+	
+		Graphics()->TextureClear();
+		Graphics()->QuadsBegin();
+		Graphics()->SetColor(0, 0, 0, 0.3f);
+		DrawCircle(Screen.w / 2, Screen.h / 2, 30.0f, 64);
+		Graphics()->QuadsEnd();
+	}
+
+	RenderTools()->RenderCursor(m_SelectorMouse + vec2(Screen.w, Screen.h) / 2, 24.0f);
+}
+
+void CBindWheel::Binwheel(int Bind)
+{
+	//bindwheel 0 "123456789" "say hey"
+	char *command = GameClient()->m_bindwheellist[Bind].command;
+	char aBuf[256];
+	Console()->ExecuteLine(GameClient()->m_bindwheellist[Bind].command);
+}
+
+void CBindWheel::updateBinds(int Bindpos, char *Description, char *Command)
+{
+	str_format(GameClient()->m_bindwheellist[Bindpos].command, sizeof(GameClient()->m_bindwheellist[Bindpos].command), Command);
+	str_format(GameClient()->m_bindwheellist[Bindpos].description, sizeof(GameClient()->m_bindwheellist[Bindpos].description), Description);
+	
+	char aBuf[512];
+	str_format(aBuf, sizeof(aBuf), "[%d]: '%s' -> '%s'", Bindpos, GameClient()->m_bindwheellist[Bindpos].description,GameClient()->m_bindwheellist[Bindpos].command);
+	
+	Console()->Print(IConsole::OUTPUT_LEVEL_STANDARD, "updateBinds", aBuf);
+}
+
+void CBindWheel::ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData)
+{
+	CBindWheel *pSelf = (CBindWheel *)pUserData;
+
+	char aBuf[128];
+	const char *pEnd = aBuf + sizeof(aBuf) - 4;
+	for(int i = 0; i < NUM_BINDWHEEL ; ++i)
+	{
+		char *command = pSelf->GameClient()->m_bindwheellist[i].command;
+		char *description = pSelf->GameClient()->m_bindwheellist[i].description;
+		str_format(aBuf, sizeof(aBuf), "bindwheel %d \"%s\" \"%s\"",i,description,command);
+
+		pConfigManager->WriteLine(aBuf);
+	}
+}

--- a/src/game/client/components/bindwheel.cpp
+++ b/src/game/client/components/bindwheel.cpp
@@ -153,17 +153,19 @@ void CBindWheel::OnRender()
 	for(int i = 0; i < NUM_BINDWHEEL; i++)
 	{
 		float Angle = 2 * pi * i / NUM_BINDWHEEL;
-
 		float margin = 170.0f;
-		if(!(Angle >= 0 && Angle <= 90 || Angle >= 270 && Angle <= 359))
-		{
-			margin = 120.0;
-		}
+
 		if(Angle > pi)
         {
             Angle -= 2 * pi;
         }
 		
+		int orgAngle = 2 * pi * i / NUM_BINDWHEEL;
+		if(orgAngle >= 0 && orgAngle < 2 || orgAngle>=4 && orgAngle<6)
+		{
+			margin = 120.0f;
+		}
+
 		bool Selected = m_SelectedBind == i;
 
 		float Size = Selected ? 14.0 : 12.0f;
@@ -172,8 +174,9 @@ void CBindWheel::OnRender()
 		float NudgeY = 150.0f * sinf(Angle);
 
 		char aBuf[8];
-		str_format(aBuf, sizeof(aBuf), GameClient()->m_bindwheellist[i].description);
-		TextRender()->Text(0, Screen.w / 2 + NudgeX, Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
+		str_format(aBuf, sizeof(aBuf), "%s", GameClient()->m_bindwheellist[i].description);
+		//str_format(aBuf, sizeof(aBuf), "%d -> %d", inv, orgAngle);
+		TextRender()->Text(0, Screen.w / 2 + NudgeX , Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
 	}
 	Graphics()->WrapNormal();
 

--- a/src/game/client/components/bindwheel.cpp
+++ b/src/game/client/components/bindwheel.cpp
@@ -27,8 +27,8 @@ void CBindWheel::ConBindwheel(IConsole::IResult *pResult, void *pUserData)
 void CBindWheel::ConBind(IConsole::IResult *pResult, void *pUserData)
 {
 	int bindpos = pResult->GetInteger(0);
-	char command[128];
-	char description[8];
+	char command[MAX_BINDWHEEL_CMD];
+	char description[MAX_BINDWHEEL_DESC];
 	str_format(description, sizeof(description), pResult->GetString(1));
 	str_format(command, sizeof(command), pResult->GetString(2));
 
@@ -43,8 +43,8 @@ void CBindWheel::ConchainBindwheel(IConsole::IResult *pResult, void *pUserData, 
 	if(pResult->NumArguments() == 3)
 	{
 		int bindpos = pResult->GetInteger(0);
-		char command[128];
-		char description[8];
+		char command[MAX_BINDWHEEL_CMD];
+		char description[MAX_BINDWHEEL_DESC];
 		str_format(description, sizeof(description), pResult->GetString(1));
 		str_format(command, sizeof(command), pResult->GetString(2));
 
@@ -61,7 +61,7 @@ void CBindWheel::OnConsoleInit()
 		pConfigManager->RegisterTCallback(ConfigSaveCallback, this);
 
 	Console()->Register("+bindwheel", "", CFGFLAG_CLIENT, ConBindwheel, this, "Open bindwheel selector");
-	Console()->Register("bindwheel", "i[bindwheel] s[description:128] s[command:8]", CFGFLAG_CLIENT, ConBind, this, "Edit the command");
+	Console()->Register("bindwheel", "i[bindwheel] s[description:128] s[command:10]", CFGFLAG_CLIENT, ConBind, this, "Edit the command");
 	Console()->Chain("bindwheel", ConchainBindwheel, this);
 
 
@@ -173,7 +173,7 @@ void CBindWheel::OnRender()
 		float NudgeX = margin * cosf(Angle);
 		float NudgeY = 150.0f * sinf(Angle);
 
-		char aBuf[8];
+		char aBuf[MAX_BINDWHEEL_DESC];
 		str_format(aBuf, sizeof(aBuf), "%s", GameClient()->m_bindwheellist[i].description);
 		//str_format(aBuf, sizeof(aBuf), "%d -> %d", inv, orgAngle);
 		TextRender()->Text(0, Screen.w / 2 + NudgeX , Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);

--- a/src/game/client/components/bindwheel.cpp
+++ b/src/game/client/components/bindwheel.cpp
@@ -153,19 +153,12 @@ void CBindWheel::OnRender()
 	for(int i = 0; i < NUM_BINDWHEEL; i++)
 	{
 		float Angle = 2 * pi * i / NUM_BINDWHEEL;
-		float margin = 170.0f;
+		float margin = 140.0f;
 
 		if(Angle > pi)
         {
             Angle -= 2 * pi;
         }
-		
-		int orgAngle = 2 * pi * i / NUM_BINDWHEEL;
-		if(orgAngle >= 0 && orgAngle < 2 || orgAngle>=4 && orgAngle<6)
-		{
-			margin = 120.0f;
-		}
-
 		bool Selected = m_SelectedBind == i;
 
 		float Size = Selected ? 14.0 : 12.0f;
@@ -176,7 +169,7 @@ void CBindWheel::OnRender()
 		char aBuf[MAX_BINDWHEEL_DESC];
 		str_format(aBuf, sizeof(aBuf), "%s", GameClient()->m_bindwheellist[i].description);
 		//str_format(aBuf, sizeof(aBuf), "%d -> %d", inv, orgAngle);
-		TextRender()->Text(0, Screen.w / 2 + NudgeX , Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
+		TextRender()->Text(0, Screen.w / 2 + NudgeX - TextRender()->TextWidth(0, Size, aBuf, -1, -1.0f)*0.5, Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
 	}
 	Graphics()->WrapNormal();
 

--- a/src/game/client/components/bindwheel.cpp
+++ b/src/game/client/components/bindwheel.cpp
@@ -58,7 +58,7 @@ void CBindWheel::OnConsoleInit()
 {
 	IConfigManager *pConfigManager = Kernel()->RequestInterface<IConfigManager>();
 	if(pConfigManager)
-		pConfigManager->RegisterCallback(ConfigSaveCallback, this);
+		pConfigManager->RegisterTCallback(ConfigSaveCallback, this);
 
 	Console()->Register("+bindwheel", "", CFGFLAG_CLIENT, ConBindwheel, this, "Open bindwheel selector");
 	Console()->Register("bindwheel", "i[bindwheel] s[description:128] s[command:8]", CFGFLAG_CLIENT, ConBind, this, "Edit the command");

--- a/src/game/client/components/bindwheel.h
+++ b/src/game/client/components/bindwheel.h
@@ -1,0 +1,13 @@
+
+#ifndef GAME_CLIENT_COMPONENTS_BIND_WHEEL_H
+#define GAME_CLIENT_COMPONENTS_BIND_WHEEL_H
+#include <game/client/component.h>
+
+class CBindWheel : public CComponent
+{
+public:
+	virtual int Sizeof() const override { return sizeof(*this); }
+	
+};
+
+#endif

--- a/src/game/client/components/bindwheel.h
+++ b/src/game/client/components/bindwheel.h
@@ -3,7 +3,11 @@
 #define GAME_CLIENT_COMPONENTS_BIND_WHEEL_H
 #include <game/client/component.h>
 class IConfigManager;
+
 #define NUM_BINDWHEEL 8
+#define MAX_BINDWHEEL_DESC 11
+#define MAX_BINDWHEEL_CMD 128
+
 class CBindWheel : public CComponent
 {
     void DrawCircle(float x, float y, float r, int Segments);

--- a/src/game/client/components/bindwheel.h
+++ b/src/game/client/components/bindwheel.h
@@ -3,7 +3,7 @@
 #define GAME_CLIENT_COMPONENTS_BIND_WHEEL_H
 #include <game/client/component.h>
 class IConfigManager;
-
+#define NUM_BINDWHEEL 8
 class CBindWheel : public CComponent
 {
     void DrawCircle(float x, float y, float r, int Segments);

--- a/src/game/client/components/bindwheel.h
+++ b/src/game/client/components/bindwheel.h
@@ -2,12 +2,37 @@
 #ifndef GAME_CLIENT_COMPONENTS_BIND_WHEEL_H
 #define GAME_CLIENT_COMPONENTS_BIND_WHEEL_H
 #include <game/client/component.h>
+class IConfigManager;
 
 class CBindWheel : public CComponent
 {
+    void DrawCircle(float x, float y, float r, int Segments);
+
+	bool m_WasActive;
+	bool m_Active;
+
+	vec2 m_SelectorMouse;
+	int m_SelectedBind;
+	int m_SelectedEyeEmote;
+
+	static void ConBindwheel(IConsole::IResult *pResult, void *pUserData);
+	static void ConBind(IConsole::IResult *pResult, void *pUserData);
+	static void ConfigSaveCallback(IConfigManager *pConfigManager, void *pUserData);
+
 public:
+	CBindWheel();
 	virtual int Sizeof() const override { return sizeof(*this); }
+
+	virtual void OnReset() override;
+	virtual void OnConsoleInit() override;
+	virtual void OnRender() override;
+	virtual void OnRelease() override;
+	virtual bool OnCursorMove(float x, float y, IInput::ECursorType CursorType) override;
+	static void ConchainBindwheel(IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData);
 	
+	void updateBinds(int Bindpos, char *Description, char *Command);
+	void Binwheel(int Bind);
+
 };
 
 #endif

--- a/src/game/client/components/hud.cpp
+++ b/src/game/client/components/hud.cpp
@@ -789,6 +789,16 @@ void CHud::RenderTeambalanceWarning()
 
 void CHud::RenderVoting()
 {
+	
+    bool kickvote = str_startswith(m_pClient->m_Voting.VoteDescription(),"Kick ")   != 0 ? true: false;
+    bool specvote = str_startswith(m_pClient->m_Voting.VoteDescription(),"Pause ")  != 0 ? true : false;
+
+    if(g_Config.m_ClVoteDontShow &&  (kickvote || specvote)) 
+	{ // only show votes
+	  // check if the is a playervote and if he is in your team.
+	}
+
+
 	if((!g_Config.m_ClShowVotesAfterVoting && !m_pClient->m_Scoreboard.Active() && m_pClient->m_Voting.TakenChoice()) || !m_pClient->m_Voting.IsVoting() || Client()->State() == IClient::STATE_DEMOPLAYBACK)
 		return;
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3347,291 +3347,56 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 		const float Margin = 10.0f;
 		const float HeaderHeight = FontSize + 5.0f + Margin;
 
-		//create the buttons
-		CUIRect b1, b2, b3, b4, b5, b6, b7, b8;
+		CUIRect buttons[NUM_BINDWHEEL];
+		char pD[NUM_BINDWHEEL][8];
+		char pC[NUM_BINDWHEEL][128];
+
 		const char *pDescriptionFallback = "EMPTY";
-		//fill the chars with description
-		char pD1[8], pD2[8], pD3[8], pD4[8], pD5[8], pD6[8], pD7[8], pD8[8];
-		str_format(pD1, sizeof(pD1), GameClient()->m_bindwheellist[0].description);
-		str_format(pD2, sizeof(pD2), GameClient()->m_bindwheellist[1].description);
-		str_format(pD3, sizeof(pD3), GameClient()->m_bindwheellist[2].description);
-		str_format(pD4, sizeof(pD4), GameClient()->m_bindwheellist[3].description);
-		str_format(pD5, sizeof(pD5), GameClient()->m_bindwheellist[4].description);
-		str_format(pD6, sizeof(pD6), GameClient()->m_bindwheellist[5].description);
-		str_format(pD7, sizeof(pD7), GameClient()->m_bindwheellist[6].description);
-		str_format(pD8, sizeof(pD8), GameClient()->m_bindwheellist[7].description);
 
-		// fill the chars with command
-		char pC1[128], pC2[128], pC3[128], pC4[128], pC5[128], pC6[128], pC7[128], pC8[128];
-		str_format(pC1, sizeof(pC1), GameClient()->m_bindwheellist[0].command);
-		str_format(pC2, sizeof(pC2), GameClient()->m_bindwheellist[1].command);
-		str_format(pC3, sizeof(pC3), GameClient()->m_bindwheellist[2].command);
-		str_format(pC4, sizeof(pC4), GameClient()->m_bindwheellist[3].command);
-		str_format(pC5, sizeof(pC5), GameClient()->m_bindwheellist[4].command);
-		str_format(pC6, sizeof(pC6), GameClient()->m_bindwheellist[5].command);
-		str_format(pC7, sizeof(pC7), GameClient()->m_bindwheellist[6].command);
-		str_format(pC8, sizeof(pC8), GameClient()->m_bindwheellist[7].command);
-
-		// bindwheel 1
+		for(int i = 0; i < NUM_BINDWHEEL; i++)
 		{
-			// Description 1
+			str_format(pD[i], sizeof(pD[i]), GameClient()->m_bindwheellist[i].description);
+
+			str_format(pC[i], sizeof(pC[i]), GameClient()->m_bindwheellist[i].command);
+		
+			// Description
 			MainView.HSplitTop(15.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b1, &MainView);
-			b1.VSplitLeft(80.0f, &Label, &b1);
-			b1.VSplitLeft(150.0f, &b1, 0);
+			MainView.HSplitTop(20.0f, &buttons[i], &MainView);
+			buttons[i].VSplitLeft(80.0f, &Label, &buttons[i]);
+			buttons[i].VSplitLeft(150.0f, &buttons[i], 0);
 			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 1"));
+			str_format(aBuf, sizeof(aBuf), "%s %d:", Localize("Description"), i + 1);
 			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
 			static float s_OffsetName = 0.0f;
 			SUIExEditBoxProperties EditProps;
 			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD1, &b1, pD1, sizeof(GameClient()->m_bindwheellist[0].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			if(UIEx()->DoEditBox(pD[i], &buttons[i], pD[i], sizeof(GameClient()->m_bindwheellist[i].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
 			{
-				str_format(GameClient()->m_bindwheellist[0].description, sizeof(GameClient()->m_bindwheellist[0].description), pD1);
+				str_format(GameClient()->m_bindwheellist[i].description, sizeof(GameClient()->m_bindwheellist[i].description), pD[i]);
 			}
 
-			// Command 1
+			//Command
+			//  Command 1
 			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b1, &MainView);
-			b1.VSplitLeft(80.0f, &Label, &b1);
-			b1.VSplitLeft(150.0f, &b1, 0);
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 1"));
+			MainView.HSplitTop(20.0f, &buttons[i], &MainView);
+			buttons[i].VSplitLeft(80.0f, &Label, &buttons[i]);
+			buttons[i].VSplitLeft(150.0f, &buttons[i], 0);
+			str_format(aBuf, sizeof(aBuf), "%s %d:", Localize("Command"), i+1);
 			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
 			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC1, &b1, pC1, sizeof(GameClient()->m_bindwheellist[0].command), 14.0f, &s_OffsetClan))
+			if(UIEx()->DoEditBox(pC[i], &buttons[i], pC[i], sizeof(GameClient()->m_bindwheellist[i].command), 14.0f, &s_OffsetClan))
 			{
-				str_format(GameClient()->m_bindwheellist[0].command, sizeof(GameClient()->m_bindwheellist[0].command), pC1);
+				str_format(GameClient()->m_bindwheellist[i].command, sizeof(GameClient()->m_bindwheellist[i].command), pC[i]);
+			}
+
+			if(NUM_BINDWHEEL / 2 == i + 1)
+			{
+				MainView = Column;
+
+				MainView.HSplitTop(30.0f, &Section, &MainView);
+				MainView.VSplitLeft(MainView.w * 0.5, 0, &MainView);
 			}
 		}
-
-        // bindwheel 2
-		{
-			// Description 2
-			MainView.HSplitTop(50.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b2, &MainView);
-			b2.VSplitLeft(80.0f, &Label, &b2);
-			b2.VSplitLeft(150.0f, &b2, 0);
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 2"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetName = 0.0f;
-			SUIExEditBoxProperties EditProps;
-			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD2, &b2, pD2, sizeof(GameClient()->m_bindwheellist[1].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
-			{
-				str_format(GameClient()->m_bindwheellist[1].description, sizeof(GameClient()->m_bindwheellist[1].description), pD2);
-			}
-
-			// Command 2
-			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b2, &MainView);
-			b2.VSplitLeft(80.0f, &Label, &b2);
-			b2.VSplitLeft(150.0f, &b2, 0);
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 2"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC2, &b2, pC2, sizeof(GameClient()->m_bindwheellist[1].command), 14.0f, &s_OffsetClan))
-			{
-				str_format(GameClient()->m_bindwheellist[1].command, sizeof(GameClient()->m_bindwheellist[1].command), pC2);
-			}
-		}
-
-       // bindwheel 3
-		{
-			// Description 2
-			MainView.HSplitTop(50.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b3, &MainView);
-			b3.VSplitLeft(80.0f, &Label, &b3);
-			b3.VSplitLeft(150.0f, &b3, 0);
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 3"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetName = 0.0f;
-			SUIExEditBoxProperties EditProps;
-			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD3, &b3, pD3, sizeof(GameClient()->m_bindwheellist[2].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
-			{
-				str_format(GameClient()->m_bindwheellist[2].description, sizeof(GameClient()->m_bindwheellist[2].description), pD3);
-			}
-
-			// Command 2
-			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b3, &MainView);
-			b3.VSplitLeft(80.0f, &Label, &b3);
-			b3.VSplitLeft(150.0f, &b3, 0);
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 3"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC3, &b3, pC3, sizeof(GameClient()->m_bindwheellist[2].command), 14.0f, &s_OffsetClan))
-			{
-				str_format(GameClient()->m_bindwheellist[2].command, sizeof(GameClient()->m_bindwheellist[2].command), pC3);
-			}
-		}
-
-       // bindwheel 4
-		{
-			// Description 2
-			MainView.HSplitTop(50.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b4, &MainView);
-			b4.VSplitLeft(80.0f, &Label, &b4);
-			b4.VSplitLeft(150.0f, &b4, 0);
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 4"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetName = 0.0f;
-			SUIExEditBoxProperties EditProps;
-			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD4, &b4, pD4, sizeof(GameClient()->m_bindwheellist[3].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
-			{
-				str_format(GameClient()->m_bindwheellist[3].description, sizeof(GameClient()->m_bindwheellist[3].description), pD4);
-			}
-
-			// Command 2
-			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b4, &MainView);
-			b4.VSplitLeft(80.0f, &Label, &b4);
-			b4.VSplitLeft(150.0f, &b4, 0);
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 4"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC4, &b4, pC4, sizeof(GameClient()->m_bindwheellist[3].command), 14.0f, &s_OffsetClan))
-			{
-				str_format(GameClient()->m_bindwheellist[3].command, sizeof(GameClient()->m_bindwheellist[3].command), pC4);
-			}
-		}
-	
-        MainView = Column;
-
-		MainView.HSplitTop(30.0f, &Section, &MainView);
-		MainView.VSplitLeft(MainView.w * 0.5, 0, &MainView);
-       // bindwheel 5
-		{
-			// Description 2
-			MainView.HSplitTop(15.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b5, &MainView);
-			b5.VSplitLeft(80.0f, &Label, &b5);
-			b5.VSplitLeft(150.0f, &b5, 0);
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 5"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetName = 0.0f;
-			SUIExEditBoxProperties EditProps;
-			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD5, &b5, pD5, sizeof(GameClient()->m_bindwheellist[4].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
-			{
-				str_format(GameClient()->m_bindwheellist[4].description, sizeof(GameClient()->m_bindwheellist[4].description), pD5);
-			}
-
-			// Command 2
-			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b5, &MainView);
-			b5.VSplitLeft(80.0f, &Label, &b5);
-			b5.VSplitLeft(150.0f, &b5, 0);
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 5"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC5, &b5, pC5, sizeof(GameClient()->m_bindwheellist[4].command), 14.0f, &s_OffsetClan))
-			{
-				str_format(GameClient()->m_bindwheellist[4].command, sizeof(GameClient()->m_bindwheellist[4].command), pC5);
-			}
-		}
-
-       // bindwheel 6
-		{
-			// Description 2
-			MainView.HSplitTop(50.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b6, &MainView);
-			b6.VSplitLeft(80.0f, &Label, &b6);
-			b6.VSplitLeft(150.0f, &b6, 0);
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 6"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetName = 0.0f;
-			SUIExEditBoxProperties EditProps;
-			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD6, &b6, pD6, sizeof(GameClient()->m_bindwheellist[5].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
-			{
-				str_format(GameClient()->m_bindwheellist[5].description, sizeof(GameClient()->m_bindwheellist[5].description), pD6);
-			}
-
-			// Command 2
-			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b6, &MainView);
-			b6.VSplitLeft(80.0f, &Label, &b6);
-			b6.VSplitLeft(150.0f, &b6, 0);
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 6"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC6, &b6, pC6, sizeof(GameClient()->m_bindwheellist[5].command), 14.0f, &s_OffsetClan))
-			{
-				str_format(GameClient()->m_bindwheellist[5].command, sizeof(GameClient()->m_bindwheellist[5].command), pC6);
-			}
-		}
-
-       // bindwheel 7
-		{
-			// Description 2
-			MainView.HSplitTop(50.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b7, &MainView);
-			b7.VSplitLeft(80.0f, &Label, &b7);
-			b7.VSplitLeft(150.0f, &b7, 0);
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 7"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetName = 0.0f;
-			SUIExEditBoxProperties EditProps;
-			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD7, &b7, pD7, sizeof(GameClient()->m_bindwheellist[6].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
-			{
-				str_format(GameClient()->m_bindwheellist[6].description, sizeof(GameClient()->m_bindwheellist[6].description), pD7);
-			}
-
-			// Command 2
-			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b7, &MainView);
-			b7.VSplitLeft(80.0f, &Label, &b7);
-			b7.VSplitLeft(150.0f, &b7, 0);
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 7"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC7, &b7, pC7, sizeof(GameClient()->m_bindwheellist[6].command), 14.0f, &s_OffsetClan))
-			{
-				str_format(GameClient()->m_bindwheellist[6].command, sizeof(GameClient()->m_bindwheellist[6].command), pC7);
-			}
-		}
-
-       //bindwheel 8
-		{
-			// Description 2
-			MainView.HSplitTop(50.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b8, &MainView);
-			b8.VSplitLeft(80.0f, &Label, &b8);
-			b8.VSplitLeft(150.0f, &b8, 0);
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 8"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetName = 0.0f;
-			SUIExEditBoxProperties EditProps;
-			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD8, &b8, pD8, sizeof(GameClient()->m_bindwheellist[7].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
-			{
-				str_format(GameClient()->m_bindwheellist[7].description, sizeof(GameClient()->m_bindwheellist[7].description), pD8);
-			}
-
-			// Command 2
-			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &b8, &MainView);
-			b8.VSplitLeft(80.0f, &Label, &b8);
-			b8.VSplitLeft(150.0f, &b8, 0);
-			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 8"));
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC8, &b8, pC8, sizeof(GameClient()->m_bindwheellist[7].command), 14.0f, &s_OffsetClan))
-			{
-				str_format(GameClient()->m_bindwheellist[7].command, sizeof(GameClient()->m_bindwheellist[7].command), pC8);
-			}
-		}
-
 
         // Draw Circle
 		Graphics()->TextureClear();
@@ -3640,30 +3405,31 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 		RenderTools()->DrawCircle(Screen.w / 2 - 55.0f, Screen.h / 2, 190.0f, 64);
 		Graphics()->QuadsEnd();
 
-		Graphics()->WrapClamp();
+			Graphics()->WrapClamp();
 		for(int i = 0; i < NUM_BINDWHEEL; i++)
 		{
 			float Angle = 2 * pi * i / NUM_BINDWHEEL;
+			float margin = 120.0f;
 
-			float margin = 170.0f;
-			if(!(Angle >= 0 && Angle <= 90 || Angle >= 270 && Angle <= 359))
-			{
-				margin = 120.0;
-			}
 			if(Angle > pi)
 			{
 				Angle -= 2 * pi;
 			}
 
+			int orgAngle = 2 * pi * i / NUM_BINDWHEEL;
+			if(orgAngle >= 0 && orgAngle < 2 || orgAngle >= 4 && orgAngle < 6)
+			{
+				margin = 170.0f;
+			}
 
-			float Size = 12.0f;
+			float Size =  12.0f;
 
 			float NudgeX = margin * cosf(Angle);
 			float NudgeY = 150.0f * sinf(Angle);
 
 			char aBuf[8];
-			str_format(aBuf, sizeof(aBuf), GameClient()->m_bindwheellist[i].description);
-			TextRender()->Text(0, Screen.w / 2 - 55.0f + NudgeX, Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
+			str_format(aBuf, sizeof(aBuf), "%s", GameClient()->m_bindwheellist[i].description);
+			TextRender()->Text(0, Screen.w / 2 - 100.0f + NudgeX, Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
 		}
 		Graphics()->WrapNormal();
 	}

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -863,7 +863,6 @@ static CKeyInfo gs_aKeys[] =
 		{"Hammerfly dummy", "toggle cl_dummy_hammer 0 1", 0, 0},
 
 		{"Emoticon", "+emote", 0, 0},
-        {"Bindwheel", "+bindwheel", 0, 0},
 		{"Spectator mode", "+spectate", 0, 0},
 		{"Spectate next", "spectate_next", 0, 0},
 		{"Spectate previous", "spectate_previous", 0, 0},
@@ -1276,7 +1275,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		TextRender()->Text(0, MiscSettings.x, MiscSettings.y + (HeaderHeight - FontSize) / 2.f, FontSize, Localize("Miscellaneous"), -1.0f);
 
 		MiscSettings.HSplitTop(HeaderHeight, 0, &MiscSettings);
-		DoSettingsControlsButtons(32, 45, MiscSettings);
+		DoSettingsControlsButtons(32, 44, MiscSettings);
 	}
 
 	UiDoListboxEnd(&s_ScrollValue, 0);
@@ -3341,6 +3340,7 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 	{
 		CUIRect Screen = *UI()->Screen();
 		MainView.VSplitLeft(MainView.w * 0.5, &MainView, &Column);
+		CUIRect LeftColumn = MainView;
 		MainView.HSplitTop(30.0f, &Section, &MainView);
 
 		const float FontSize = 14.0f;
@@ -3353,59 +3353,14 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 
 		const char *pDescriptionFallback = "EMPTY";
 
-		for(int i = 0; i < NUM_BINDWHEEL; i++)
-		{
-			str_format(pD[i], sizeof(pD[i]), GameClient()->m_bindwheellist[i].description);
-
-			str_format(pC[i], sizeof(pC[i]), GameClient()->m_bindwheellist[i].command);
-		
-			// Description
-			MainView.HSplitTop(15.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &buttons[i], &MainView);
-			buttons[i].VSplitLeft(80.0f, &Label, &buttons[i]);
-			buttons[i].VSplitLeft(150.0f, &buttons[i], 0);
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "%s %d:", Localize("Description"), i + 1);
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetName = 0.0f;
-			SUIExEditBoxProperties EditProps;
-			EditProps.m_pEmptyText = pDescriptionFallback;
-			if(UIEx()->DoEditBox(pD[i], &buttons[i], pD[i], sizeof(GameClient()->m_bindwheellist[i].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
-			{
-				str_format(GameClient()->m_bindwheellist[i].description, sizeof(GameClient()->m_bindwheellist[i].description), pD[i]);
-			}
-
-			//Command
-			//  Command 1
-			MainView.HSplitTop(5.0f, 0, &MainView);
-			MainView.HSplitTop(20.0f, &buttons[i], &MainView);
-			buttons[i].VSplitLeft(80.0f, &Label, &buttons[i]);
-			buttons[i].VSplitLeft(150.0f, &buttons[i], 0);
-			str_format(aBuf, sizeof(aBuf), "%s %d:", Localize("Command"), i+1);
-			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
-			static float s_OffsetClan = 0.0f;
-			if(UIEx()->DoEditBox(pC[i], &buttons[i], pC[i], sizeof(GameClient()->m_bindwheellist[i].command), 14.0f, &s_OffsetClan))
-			{
-				str_format(GameClient()->m_bindwheellist[i].command, sizeof(GameClient()->m_bindwheellist[i].command), pC[i]);
-			}
-
-			if(NUM_BINDWHEEL / 2 == i + 1)
-			{
-				MainView = Column;
-
-				MainView.HSplitTop(30.0f, &Section, &MainView);
-				MainView.VSplitLeft(MainView.w * 0.5, 0, &MainView);
-			}
-		}
-
-        // Draw Circle
+		// Draw Circle
 		Graphics()->TextureClear();
 		Graphics()->QuadsBegin();
 		Graphics()->SetColor(0, 0, 0, 0.3f);
 		RenderTools()->DrawCircle(Screen.w / 2 - 55.0f, Screen.h / 2, 190.0f, 64);
 		Graphics()->QuadsEnd();
 
-			Graphics()->WrapClamp();
+		Graphics()->WrapClamp();
 		for(int i = 0; i < NUM_BINDWHEEL; i++)
 		{
 			float Angle = 2 * pi * i / NUM_BINDWHEEL;
@@ -3422,7 +3377,7 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 				margin = 170.0f;
 			}
 
-			float Size =  12.0f;
+			float Size = 12.0f;
 
 			float NudgeX = margin * cosf(Angle);
 			float NudgeY = 150.0f * sinf(Angle);
@@ -3432,6 +3387,94 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 			TextRender()->Text(0, Screen.w / 2 - 100.0f + NudgeX, Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
 		}
 		Graphics()->WrapNormal();
+
+
+
+		for(int i = 0; i < NUM_BINDWHEEL; i++)
+		{
+			str_format(pD[i], sizeof(pD[i]), GameClient()->m_bindwheellist[i].description);
+
+			str_format(pC[i], sizeof(pC[i]), GameClient()->m_bindwheellist[i].command);
+
+			// Description
+			MainView.HSplitTop(15.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &buttons[i], &MainView);
+			buttons[i].VSplitLeft(80.0f, &Label, &buttons[i]);
+			buttons[i].VSplitLeft(150.0f, &buttons[i], 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s %d:", Localize("Description"), i + 1);
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD[i], &buttons[i], pD[i], sizeof(GameClient()->m_bindwheellist[i].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[i].description, sizeof(GameClient()->m_bindwheellist[i].description), pD[i]);
+			}
+
+			// Command
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &buttons[i], &MainView);
+			buttons[i].VSplitLeft(80.0f, &Label, &buttons[i]);
+			buttons[i].VSplitLeft(150.0f, &buttons[i], 0);
+			str_format(aBuf, sizeof(aBuf), "%s %d:", Localize("Command"), i + 1);
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC[i], &buttons[i], pC[i], sizeof(GameClient()->m_bindwheellist[i].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[i].command, sizeof(GameClient()->m_bindwheellist[i].command), pC[i]);
+			}
+
+			if(NUM_BINDWHEEL / 2 == i + 1)
+			{
+				MainView = Column;
+				MainView.VSplitRight(500, 0, &MainView);
+
+				MainView.HSplitTop(30.0f, &Section, &MainView);
+				MainView.VSplitLeft(MainView.w * 0.5, 0, &MainView);
+			}
+		}
+
+
+		// Do Settings Key
+		{
+			CKeyInfo &Key = CKeyInfo{"Bind Wheel Key", "+bindwheel", 0, 0};
+			for(int Mod = 0; Mod < CBinds::MODIFIER_COMBINATION_COUNT; Mod++)
+			{
+				for(int KeyId = 0; KeyId < KEY_LAST; KeyId++)
+				{
+					const char *pBind = m_pClient->m_Binds.Get(KeyId, Mod);
+					if(!pBind[0])
+						continue;
+
+					if(str_comp(pBind, Key.m_pCommand) == 0)
+					{
+						Key.m_KeyId = KeyId;
+						Key.m_ModifierCombination = Mod;
+						break;
+					}
+				}
+			}
+
+			CUIRect Button, Label;
+			LeftColumn.HSplitBottom(20.0f, &LeftColumn, 0);
+			LeftColumn.HSplitBottom(20.0f, &LeftColumn, &Button);
+			Button.VSplitLeft(120.0f, &Label, &Button);
+			Button.VSplitLeft(100, &Button, 0);
+			char aBuf[64];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize((const char *)Key.m_Name));
+
+			UI()->DoLabel(&Label, aBuf, 13.0f, TEXTALIGN_LEFT);
+			int OldId = Key.m_KeyId, OldModifierCombination = Key.m_ModifierCombination, NewModifierCombination;
+			int NewId = DoKeyReader((void *)&Key.m_Name, &Button, OldId, OldModifierCombination, &NewModifierCombination);
+			if(NewId != OldId || NewModifierCombination != OldModifierCombination)
+			{
+				if(OldId != 0 || NewId == 0)
+					m_pClient->m_Binds.Bind(OldId, "", false, OldModifierCombination);
+				if(NewId != 0)
+					m_pClient->m_Binds.Bind(NewId, Key.m_pCommand, false, NewModifierCombination);
+			}
+		}
 	}
 }
 
@@ -3584,7 +3627,6 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 
 		str_format(aName, sizeof(aName), ("%s"), m_Dummy ? g_Config.m_ClDummyName : g_Config.m_PlayerName);
 		str_format(aClan, sizeof(aClan), ("%s"), m_Dummy ? g_Config.m_ClDummyClan : g_Config.m_PlayerClan);
-
 	}
 	else
 	{
@@ -3781,7 +3823,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 
 			Item.m_Rect.VSplitRight(60.0, &BodyColorSquare, &FlagRect);
 			BodyColorSquare.x -= 11.0;
-			BodyColorSquare.VSplitLeft(10, &BodyColorSquare,0 );
+			BodyColorSquare.VSplitLeft(10, &BodyColorSquare, 0);
 			BodyColorSquare.HSplitMid(&BodyColorSquare, &FeetColorSquare);
 			BodyColorSquare.HSplitMid(0, &BodyColorSquare);
 			FeetColorSquare.HSplitMid(&FeetColorSquare, 0);
@@ -3797,7 +3839,6 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 
 			if(CurrentProfile.BodyColor != -1 && CurrentProfile.FeetColor != -1)
 			{
-
 				ColorRGBA BodyColor = color_cast<ColorRGBA>(ColorHSLA(CurrentProfile.BodyColor).UnclampLighting());
 				ColorRGBA FeetColor = color_cast<ColorRGBA>(ColorHSLA(CurrentProfile.FeetColor).UnclampLighting());
 

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3382,7 +3382,7 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 			float NudgeX = margin * cosf(Angle);
 			float NudgeY = 150.0f * sinf(Angle);
 
-			char aBuf[8];
+			char aBuf[MAX_BINDWHEEL_DESC];
 			str_format(aBuf, sizeof(aBuf), "%s", GameClient()->m_bindwheellist[i].description);
 			TextRender()->Text(0, Screen.w / 2 - 100.0f + NudgeX, Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
 		}
@@ -3584,12 +3584,13 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 			OwnSkinInfo.m_OriginalRenderSkin = pLoadSkin->m_OriginalSkin;
 			OwnSkinInfo.m_ColorableRenderSkin = pLoadSkin->m_ColorableSkin;
 			OwnSkinInfo.m_SkinMetrics = pLoadSkin->m_Metrics;
-			if(*pUseCustomColor && doColors && LoadProfile.BodyColor != -1 && LoadProfile.FeetColor != -1)
-			{
-				OwnSkinInfo.m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(LoadProfile.BodyColor).UnclampLighting());
-				OwnSkinInfo.m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(LoadProfile.FeetColor).UnclampLighting());
-			}
 		}
+		if(*pUseCustomColor && doColors && LoadProfile.BodyColor != -1 && LoadProfile.FeetColor != -1)
+		{
+			OwnSkinInfo.m_ColorBody = color_cast<ColorRGBA>(ColorHSLA(LoadProfile.BodyColor).UnclampLighting());
+			OwnSkinInfo.m_ColorFeet = color_cast<ColorRGBA>(ColorHSLA(LoadProfile.FeetColor).UnclampLighting());
+		}
+
 		RenderTools()->GetRenderTeeOffsetToRenderedTee(pIdleState, &OwnSkinInfo, OffsetToMid);
 		TeeRenderPos = vec2(Label.x + 20.0f, Label.y + Label.h / 2.0f + OffsetToMid.y);
 		int LoadEmote = Emote;
@@ -3710,6 +3711,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 					g_Config.m_ClDummyCountry = LoadProfile.CountryFlag;
 			}
 		}
+		SetNeedSendInfo();
 		m_DoubleClickIndex = -1;
 	}
 	LabelRight.HSplitTop(5.0f, 0, &LabelRight);

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2981,29 +2981,40 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 	}
 }
 
+enum
+{
+	TCLIENT_TAB_PAGE1 = 0,
+	TCLIENT_TAB_PAGE2 = 1,
+	TCLIENT_TAB_BINDWHEEL = 2,
+	NUMBER_OF_TCLIENT_TABS = 3,
+};
+
 void CMenus::RenderSettingsTClient(CUIRect MainView)
 {
 	static int s_CurCustomTab = 0;
 
-	CUIRect Column, Section, Page1Tab, Page2Tab, Label;
+	CUIRect Column, Section, TabBar, Page1Tab, Page2Tab, Page3Tab, Label;
 
 	MainView.HMargin(-15.0f, &MainView);
 
 	MainView.HSplitTop(20, &Label, &MainView);
 	float TabsW = Label.w;
-	Label.VSplitLeft(TabsW / 2, &Page1Tab, &Page2Tab);
+	Label.VSplitLeft(TabsW / NUMBER_OF_TCLIENT_TABS, &Page1Tab, &Page2Tab);
+	Page2Tab.VSplitLeft(TabsW / NUMBER_OF_TCLIENT_TABS, &Page2Tab, &Page3Tab);
 
-	static int s_aPageTabs[2] = {};
+	static int s_aPageTabs[NUMBER_OF_TCLIENT_TABS] = {};
 
-	if(DoButton_MenuTab((void *)&s_aPageTabs[0], Localize("Page 1"), s_CurCustomTab == 0, &Page1Tab, 5, NULL, NULL, NULL, NULL, 4))
-		s_CurCustomTab = 0;
-	if(DoButton_MenuTab((void *)&s_aPageTabs[1], Localize("Page 2"), s_CurCustomTab == 1, &Page2Tab, 5, NULL, NULL, NULL, NULL, 4))
-		s_CurCustomTab = 1;
+	if(DoButton_MenuTab((void *)&s_aPageTabs[TCLIENT_TAB_PAGE1], Localize("Page 1"), s_CurCustomTab == TCLIENT_TAB_PAGE1, &Page1Tab, 5, NULL, NULL, NULL, NULL, 4))
+		s_CurCustomTab = TCLIENT_TAB_PAGE1;
+	if(DoButton_MenuTab((void *)&s_aPageTabs[TCLIENT_TAB_PAGE2], Localize("Page 2"), s_CurCustomTab == TCLIENT_TAB_PAGE2, &Page2Tab, 0, NULL, NULL, NULL, NULL, 4))
+		s_CurCustomTab = TCLIENT_TAB_PAGE2;
+	if(DoButton_MenuTab((void *)&s_aPageTabs[TCLIENT_TAB_BINDWHEEL], Localize("BindWheel"), s_CurCustomTab == TCLIENT_TAB_BINDWHEEL, &Page3Tab, 10, NULL, NULL, NULL, NULL, 4))
+		s_CurCustomTab = TCLIENT_TAB_BINDWHEEL;
 
 	const float LineMargin = 20.0f;
 
-	//MainView.HSplitTop(10.0f, 0x0, &MainView);
-	if(s_CurCustomTab == 0)
+	// MainView.HSplitTop(10.0f, 0x0, &MainView);
+	if(s_CurCustomTab == TCLIENT_TAB_PAGE1)
 	{
 		MainView.VSplitLeft(MainView.w * 0.5, &MainView, &Column);
 
@@ -3183,7 +3194,7 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 		DoLine_ColorPicker(&OutlineColorUnfreezeID, 25.0f, 200.0f, 14.0f, 0.0f, &Section, ("Unfreeze Outline Color"), &g_Config.m_ClOutlineColorUnfreeze, ColorRGBA(0.0f, 0.0f, 0.0f, 1.0f), false);
 
 		// ***** ANTI LATENCY ***** //
-		//MainView.HSplitTop(5.0f, 0, &MainView);
+		// MainView.HSplitTop(5.0f, 0, &MainView);
 
 		// MainView.VSplitLeft(-5.0f, 0x0, &MainView);
 		MainView.HSplitTop(30.0f, &Section, &MainView);
@@ -3241,7 +3252,7 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 		}
 	}
 
-	if(s_CurCustomTab == 1)
+	if(s_CurCustomTab == TCLIENT_TAB_PAGE2)
 	{
 		MainView.VSplitLeft(MainView.w * 0.5, &MainView, &Column);
 
@@ -3324,8 +3335,11 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 			g_Config.m_ClIndicatorMaxDistance = NewValue * 50;
 		}
 	}
-}
 
+	if(s_CurCustomTab == TCLIENT_TAB_BINDWHEEL)
+	{
+	}
+}
 void CMenus::RenderSettingsProfiles(CUIRect MainView)
 {
 	CUIRect Label, LabelMid, Section, LabelRight;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -3348,8 +3348,8 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 		const float HeaderHeight = FontSize + 5.0f + Margin;
 
 		CUIRect buttons[NUM_BINDWHEEL];
-		char pD[NUM_BINDWHEEL][8];
-		char pC[NUM_BINDWHEEL][128];
+		char pD[NUM_BINDWHEEL][MAX_BINDWHEEL_DESC];
+		char pC[NUM_BINDWHEEL][MAX_BINDWHEEL_CMD];
 
 		const char *pDescriptionFallback = "EMPTY";
 
@@ -3401,7 +3401,7 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 			MainView.HSplitTop(20.0f, &buttons[i], &MainView);
 			buttons[i].VSplitLeft(80.0f, &Label, &buttons[i]);
 			buttons[i].VSplitLeft(150.0f, &buttons[i], 0);
-			char aBuf[128];
+			char aBuf[MAX_BINDWHEEL_CMD];
 			str_format(aBuf, sizeof(aBuf), "%s %d:", Localize("Description"), i + 1);
 			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
 			static float s_OffsetName = 0.0f;

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -863,6 +863,7 @@ static CKeyInfo gs_aKeys[] =
 		{"Hammerfly dummy", "toggle cl_dummy_hammer 0 1", 0, 0},
 
 		{"Emoticon", "+emote", 0, 0},
+        {"Bindwheel", "+bindwheel", 0, 0},
 		{"Spectator mode", "+spectate", 0, 0},
 		{"Spectate next", "spectate_next", 0, 0},
 		{"Spectate previous", "spectate_previous", 0, 0},
@@ -1275,7 +1276,7 @@ void CMenus::RenderSettingsControls(CUIRect MainView)
 		TextRender()->Text(0, MiscSettings.x, MiscSettings.y + (HeaderHeight - FontSize) / 2.f, FontSize, Localize("Miscellaneous"), -1.0f);
 
 		MiscSettings.HSplitTop(HeaderHeight, 0, &MiscSettings);
-		DoSettingsControlsButtons(32, 44, MiscSettings);
+		DoSettingsControlsButtons(32, 45, MiscSettings);
 	}
 
 	UiDoListboxEnd(&s_ScrollValue, 0);
@@ -3338,8 +3339,336 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 
 	if(s_CurCustomTab == TCLIENT_TAB_BINDWHEEL)
 	{
+		CUIRect Screen = *UI()->Screen();
+		MainView.VSplitLeft(MainView.w * 0.5, &MainView, &Column);
+		MainView.HSplitTop(30.0f, &Section, &MainView);
+
+		const float FontSize = 14.0f;
+		const float Margin = 10.0f;
+		const float HeaderHeight = FontSize + 5.0f + Margin;
+
+		//create the buttons
+		CUIRect b1, b2, b3, b4, b5, b6, b7, b8;
+		const char *pDescriptionFallback = "EMPTY";
+		//fill the chars with description
+		char pD1[8], pD2[8], pD3[8], pD4[8], pD5[8], pD6[8], pD7[8], pD8[8];
+		str_format(pD1, sizeof(pD1), GameClient()->m_bindwheellist[0].description);
+		str_format(pD2, sizeof(pD2), GameClient()->m_bindwheellist[1].description);
+		str_format(pD3, sizeof(pD3), GameClient()->m_bindwheellist[2].description);
+		str_format(pD4, sizeof(pD4), GameClient()->m_bindwheellist[3].description);
+		str_format(pD5, sizeof(pD5), GameClient()->m_bindwheellist[4].description);
+		str_format(pD6, sizeof(pD6), GameClient()->m_bindwheellist[5].description);
+		str_format(pD7, sizeof(pD7), GameClient()->m_bindwheellist[6].description);
+		str_format(pD8, sizeof(pD8), GameClient()->m_bindwheellist[7].description);
+
+		// fill the chars with command
+		char pC1[128], pC2[128], pC3[128], pC4[128], pC5[128], pC6[128], pC7[128], pC8[128];
+		str_format(pC1, sizeof(pC1), GameClient()->m_bindwheellist[0].command);
+		str_format(pC2, sizeof(pC2), GameClient()->m_bindwheellist[1].command);
+		str_format(pC3, sizeof(pC3), GameClient()->m_bindwheellist[2].command);
+		str_format(pC4, sizeof(pC4), GameClient()->m_bindwheellist[3].command);
+		str_format(pC5, sizeof(pC5), GameClient()->m_bindwheellist[4].command);
+		str_format(pC6, sizeof(pC6), GameClient()->m_bindwheellist[5].command);
+		str_format(pC7, sizeof(pC7), GameClient()->m_bindwheellist[6].command);
+		str_format(pC8, sizeof(pC8), GameClient()->m_bindwheellist[7].command);
+
+		// bindwheel 1
+		{
+			// Description 1
+			MainView.HSplitTop(15.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b1, &MainView);
+			b1.VSplitLeft(80.0f, &Label, &b1);
+			b1.VSplitLeft(150.0f, &b1, 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 1"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD1, &b1, pD1, sizeof(GameClient()->m_bindwheellist[0].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[0].description, sizeof(GameClient()->m_bindwheellist[0].description), pD1);
+			}
+
+			// Command 1
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b1, &MainView);
+			b1.VSplitLeft(80.0f, &Label, &b1);
+			b1.VSplitLeft(150.0f, &b1, 0);
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 1"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC1, &b1, pC1, sizeof(GameClient()->m_bindwheellist[0].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[0].command, sizeof(GameClient()->m_bindwheellist[0].command), pC1);
+			}
+		}
+
+        // bindwheel 2
+		{
+			// Description 2
+			MainView.HSplitTop(50.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b2, &MainView);
+			b2.VSplitLeft(80.0f, &Label, &b2);
+			b2.VSplitLeft(150.0f, &b2, 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 2"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD2, &b2, pD2, sizeof(GameClient()->m_bindwheellist[1].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[1].description, sizeof(GameClient()->m_bindwheellist[1].description), pD2);
+			}
+
+			// Command 2
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b2, &MainView);
+			b2.VSplitLeft(80.0f, &Label, &b2);
+			b2.VSplitLeft(150.0f, &b2, 0);
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 2"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC2, &b2, pC2, sizeof(GameClient()->m_bindwheellist[1].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[1].command, sizeof(GameClient()->m_bindwheellist[1].command), pC2);
+			}
+		}
+
+       // bindwheel 3
+		{
+			// Description 2
+			MainView.HSplitTop(50.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b3, &MainView);
+			b3.VSplitLeft(80.0f, &Label, &b3);
+			b3.VSplitLeft(150.0f, &b3, 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 3"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD3, &b3, pD3, sizeof(GameClient()->m_bindwheellist[2].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[2].description, sizeof(GameClient()->m_bindwheellist[2].description), pD3);
+			}
+
+			// Command 2
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b3, &MainView);
+			b3.VSplitLeft(80.0f, &Label, &b3);
+			b3.VSplitLeft(150.0f, &b3, 0);
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 3"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC3, &b3, pC3, sizeof(GameClient()->m_bindwheellist[2].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[2].command, sizeof(GameClient()->m_bindwheellist[2].command), pC3);
+			}
+		}
+
+       // bindwheel 4
+		{
+			// Description 2
+			MainView.HSplitTop(50.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b4, &MainView);
+			b4.VSplitLeft(80.0f, &Label, &b4);
+			b4.VSplitLeft(150.0f, &b4, 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 4"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD4, &b4, pD4, sizeof(GameClient()->m_bindwheellist[3].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[3].description, sizeof(GameClient()->m_bindwheellist[3].description), pD4);
+			}
+
+			// Command 2
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b4, &MainView);
+			b4.VSplitLeft(80.0f, &Label, &b4);
+			b4.VSplitLeft(150.0f, &b4, 0);
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 4"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC4, &b4, pC4, sizeof(GameClient()->m_bindwheellist[3].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[3].command, sizeof(GameClient()->m_bindwheellist[3].command), pC4);
+			}
+		}
+	
+        MainView = Column;
+
+		MainView.HSplitTop(30.0f, &Section, &MainView);
+		MainView.VSplitLeft(MainView.w * 0.5, 0, &MainView);
+       // bindwheel 5
+		{
+			// Description 2
+			MainView.HSplitTop(15.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b5, &MainView);
+			b5.VSplitLeft(80.0f, &Label, &b5);
+			b5.VSplitLeft(150.0f, &b5, 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 5"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD5, &b5, pD5, sizeof(GameClient()->m_bindwheellist[4].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[4].description, sizeof(GameClient()->m_bindwheellist[4].description), pD5);
+			}
+
+			// Command 2
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b5, &MainView);
+			b5.VSplitLeft(80.0f, &Label, &b5);
+			b5.VSplitLeft(150.0f, &b5, 0);
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 5"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC5, &b5, pC5, sizeof(GameClient()->m_bindwheellist[4].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[4].command, sizeof(GameClient()->m_bindwheellist[4].command), pC5);
+			}
+		}
+
+       // bindwheel 6
+		{
+			// Description 2
+			MainView.HSplitTop(50.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b6, &MainView);
+			b6.VSplitLeft(80.0f, &Label, &b6);
+			b6.VSplitLeft(150.0f, &b6, 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 6"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD6, &b6, pD6, sizeof(GameClient()->m_bindwheellist[5].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[5].description, sizeof(GameClient()->m_bindwheellist[5].description), pD6);
+			}
+
+			// Command 2
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b6, &MainView);
+			b6.VSplitLeft(80.0f, &Label, &b6);
+			b6.VSplitLeft(150.0f, &b6, 0);
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 6"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC6, &b6, pC6, sizeof(GameClient()->m_bindwheellist[5].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[5].command, sizeof(GameClient()->m_bindwheellist[5].command), pC6);
+			}
+		}
+
+       // bindwheel 7
+		{
+			// Description 2
+			MainView.HSplitTop(50.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b7, &MainView);
+			b7.VSplitLeft(80.0f, &Label, &b7);
+			b7.VSplitLeft(150.0f, &b7, 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 7"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD7, &b7, pD7, sizeof(GameClient()->m_bindwheellist[6].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[6].description, sizeof(GameClient()->m_bindwheellist[6].description), pD7);
+			}
+
+			// Command 2
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b7, &MainView);
+			b7.VSplitLeft(80.0f, &Label, &b7);
+			b7.VSplitLeft(150.0f, &b7, 0);
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 7"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC7, &b7, pC7, sizeof(GameClient()->m_bindwheellist[6].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[6].command, sizeof(GameClient()->m_bindwheellist[6].command), pC7);
+			}
+		}
+
+       //bindwheel 8
+		{
+			// Description 2
+			MainView.HSplitTop(50.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b8, &MainView);
+			b8.VSplitLeft(80.0f, &Label, &b8);
+			b8.VSplitLeft(150.0f, &b8, 0);
+			char aBuf[128];
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Description 8"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetName = 0.0f;
+			SUIExEditBoxProperties EditProps;
+			EditProps.m_pEmptyText = pDescriptionFallback;
+			if(UIEx()->DoEditBox(pD8, &b8, pD8, sizeof(GameClient()->m_bindwheellist[7].description), 14.0f, &s_OffsetName, false, CUI::CORNER_ALL, EditProps))
+			{
+				str_format(GameClient()->m_bindwheellist[7].description, sizeof(GameClient()->m_bindwheellist[7].description), pD8);
+			}
+
+			// Command 2
+			MainView.HSplitTop(5.0f, 0, &MainView);
+			MainView.HSplitTop(20.0f, &b8, &MainView);
+			b8.VSplitLeft(80.0f, &Label, &b8);
+			b8.VSplitLeft(150.0f, &b8, 0);
+			str_format(aBuf, sizeof(aBuf), "%s:", Localize("Command 8"));
+			UI()->DoLabel(&Label, aBuf, 14.0f, TEXTALIGN_LEFT);
+			static float s_OffsetClan = 0.0f;
+			if(UIEx()->DoEditBox(pC8, &b8, pC8, sizeof(GameClient()->m_bindwheellist[7].command), 14.0f, &s_OffsetClan))
+			{
+				str_format(GameClient()->m_bindwheellist[7].command, sizeof(GameClient()->m_bindwheellist[7].command), pC8);
+			}
+		}
+
+
+        // Draw Circle
+		Graphics()->TextureClear();
+		Graphics()->QuadsBegin();
+		Graphics()->SetColor(0, 0, 0, 0.3f);
+		RenderTools()->DrawCircle(Screen.w / 2 - 55.0f, Screen.h / 2, 190.0f, 64);
+		Graphics()->QuadsEnd();
+
+		Graphics()->WrapClamp();
+		for(int i = 0; i < NUM_BINDWHEEL; i++)
+		{
+			float Angle = 2 * pi * i / NUM_BINDWHEEL;
+
+			float margin = 170.0f;
+			if(!(Angle >= 0 && Angle <= 90 || Angle >= 270 && Angle <= 359))
+			{
+				margin = 120.0;
+			}
+			if(Angle > pi)
+			{
+				Angle -= 2 * pi;
+			}
+
+
+			float Size = 12.0f;
+
+			float NudgeX = margin * cosf(Angle);
+			float NudgeY = 150.0f * sinf(Angle);
+
+			char aBuf[8];
+			str_format(aBuf, sizeof(aBuf), GameClient()->m_bindwheellist[i].description);
+			TextRender()->Text(0, Screen.w / 2 - 55.0f + NudgeX, Screen.h / 2 + NudgeY, Size, aBuf, -1.0f);
+		}
+		Graphics()->WrapNormal();
 	}
 }
+
 void CMenus::RenderSettingsProfiles(CUIRect MainView)
 {
 	CUIRect Label, LabelMid, Section, LabelRight;

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -133,6 +133,7 @@ void CGameClient::OnConsoleInit()
 					      &m_FreezeBars,
 					      &m_DamageInd,
 					      &m_PlayerIndicator,
+                          &m_bindwheel,
 					      &m_Hud,
 					      &m_Spectator,
 					      &m_Emoticon,

--- a/src/game/client/gameclient.cpp
+++ b/src/game/client/gameclient.cpp
@@ -158,6 +158,7 @@ void CGameClient::OnConsoleInit()
 						  &m_Motd, // for pressing esc to remove it
 						  &m_Menus,
 						  &m_Spectator,
+                          &m_bindwheel,
 						  &m_Emoticon,
 						  &m_Controls,
 						  &m_Binds});
@@ -281,6 +282,9 @@ void CGameClient::OnInit()
 		}
 		++CompCounter;
 	}
+
+
+
 
 	char aBuf[256];
 
@@ -2022,6 +2026,7 @@ void CGameClient::CClientData::Reset()
 	m_Country = -1;
 	m_Team = 0;
 	m_Angle = 0;
+    m_bindwheel = 0;
 	m_Emoticon = 0;
 	m_EmoticonStartTick = -1;
 	m_EmoticonStartFraction = 0;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -134,13 +134,13 @@ public:
 	CStatboard m_Statboard;
 	CSounds m_Sounds;
 	CEmoticon m_Emoticon;
+    CBindWheel m_bindwheel;
 	CDamageInd m_DamageInd;
 	CVoting m_Voting;
 	CSpectator m_Spectator;
 
 	CPlayers m_Players;
 	CPlayerIndicator m_PlayerIndicator;
-    CBindWheel m_bindwheel;
 	COutlines m_Outlines;
 	CNamePlates m_NamePlates;
 	CFreezeBars m_FreezeBars;
@@ -200,7 +200,6 @@ private:
 	int m_aCheckInfo[NUM_DUMMIES];
 
 	char m_aDDNetVersionStr[64];
-
 	static void ConTeam(IConsole::IResult *pResult, void *pUserData);
 	static void ConKill(IConsole::IResult *pResult, void *pUserData);
 
@@ -345,6 +344,7 @@ public:
 		int m_SkinColor;
 		int m_Team;
 		int m_Emoticon;
+        int m_bindwheel;
 		float m_EmoticonStartFraction;
 		int m_EmoticonStartTick;
 		bool m_Solo;
@@ -656,6 +656,13 @@ public:
 	SClientEmoticonsSkin m_EmoticonsSkin;
 	bool m_EmoticonsSkinLoaded;
 
+	struct SClientBindWheel
+	{
+		char description[8];
+		char command[128];
+	};
+	SClientBindWheel m_bindwheellist[NUM_BINDWHEEL];
+	
 	struct SClientHudSkin
 	{
 		IGraphics::CTextureHandle m_SpriteHudAirjump;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -45,6 +45,7 @@
 #include "components/nameplates.h"
 #include "components/particles.h"
 #include "components/player_indicator.h"
+#include "components/bindwheel.h"
 #include "components/outlines.h"
 #include "components/players.h"
 #include "components/race_demo.h"
@@ -139,6 +140,7 @@ public:
 
 	CPlayers m_Players;
 	CPlayerIndicator m_PlayerIndicator;
+    CBindWheel m_bindwheel;
 	COutlines m_Outlines;
 	CNamePlates m_NamePlates;
 	CFreezeBars m_FreezeBars;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -658,8 +658,8 @@ public:
 
 	struct SClientBindWheel
 	{
-		char description[8];
-		char command[128];
+		char description[MAX_BINDWHEEL_DESC];
+		char command[MAX_BINDWHEEL_CMD];
 	};
 	SClientBindWheel m_bindwheellist[NUM_BINDWHEEL];
 	

--- a/src/game/tater_variables.h
+++ b/src/game/tater_variables.h
@@ -82,6 +82,12 @@ MACRO_CONFIG_INT(ClApplyProfileFlag, tc_profile_flag, 0, 0, 1, CFGFLAG_CLIENT | 
 MACRO_CONFIG_INT(ClApplyProfileColors, tc_profile_colors, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply colors in profiles")
 MACRO_CONFIG_INT(ClApplyProfileEmote, tc_profile_emote, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply emote in profiles")
 
+// Voting 
+MACRO_CONFIG_INT(ClVoteAuto, tc_vote_auto, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Activate auto vote")
+MACRO_CONFIG_INT(ClVoteDefaultAll, tc_vote_default, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Default vote everybody (0:yes,1:no)")
+MACRO_CONFIG_INT(ClVoteDefaultFriend, tc_vote_default, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Default vote friends (0:yes,1:no,3:Default)")
+MACRO_CONFIG_INT(ClVoteDontShow, tc_vote_show, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show only votes where your vote counts")
+MACRO_CONFIG_INT(ClVoteDontShowFriends, tc_vote_show_friends, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show only votes where your vote counts exclude friends")
 
 //AAAAAAA
 MACRO_CONFIG_INT(ClAmIFrozen, EEEfrz, 0, 0, 1, CFGFLAG_CLIENT, "")


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request -->
It is a menu wheel like the emotes and binds can be stored on it. to have faster access to it as well as a visualization 
## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)


### **Screenshots:** 

bind menu: 
![screenshot_2022-07-25_16-37-56](https://user-images.githubusercontent.com/55141362/180803710-c1c20fd8-ae7e-4294-b1ad-3e6b0df81375.png)

Bindwheel page: 
![screenshot_2022-07-25_16-38-07](https://user-images.githubusercontent.com/55141362/180803806-0e529b07-5cf4-4e7d-8e44-b2cdeeaad8b7.png)

Ingame Bindwheel:
![screenshot_2022-07-25_16-38-41](https://user-images.githubusercontent.com/55141362/180803846-574fa407-86c1-4331-ad43-e1d588748b43.png)

