### PR TITLE
Change distance to 500 so fng antibot doesnt flag

### DIFF
--- a/src/engine/shared/tater_variables.h
+++ b/src/engine/shared/tater_variables.h
@@ -24,7 +24,7 @@ MACRO_CONFIG_INT(ClPingNameCircle, tc_nameplate_ping_circle, 0, 0, 1, CFGFLAG_CL
 MACRO_CONFIG_INT(ClSpecmenuID, tc_spec_menu_ID, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Shows player IDs in spectate menu")
 
 MACRO_CONFIG_INT(ClLimitMouseToScreen, tc_limit_mouse_to_screen, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Limit mouse to screen boundries")
-MACRO_CONFIG_INT(ClImproveMousePrecision, tc_improve_mouse_precision, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Improve mouse precision by scaling max distance to 1000")
+MACRO_CONFIG_INT(ClImproveMousePrecision, tc_improve_mouse_precision, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Improve mouse precision by scaling max distance to 500")
 
 MACRO_CONFIG_INT(ClHammerRotatesWithCursor, tc_hammer_rotates_with_cursor, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Allow your hammer to rotate like other weapons")
 

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -215,8 +215,8 @@ int CControls::SnapInput(int *pData)
 		const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
 		if(!m_pClient->m_Snap.m_SpecInfo.m_Active && MaxDistance > 5) // Only multiply mouse coords if not angle bind
 		{
-			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 1000) // Don't scale if it would reduce precision
-				Pos *= length(Pos) * 1000.0f / (float)MaxDistance;
+			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 500) // Don't scale if it would reduce precision
+				Pos *= length(Pos) * 500.0f / (float)MaxDistance;
 		}
 		m_aInputData[g_Config.m_ClDummy].m_TargetX = (int)Pos.x;
 		m_aInputData[g_Config.m_ClDummy].m_TargetY = (int)Pos.y;
@@ -241,8 +241,8 @@ int CControls::SnapInput(int *pData)
 		const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
 		if(!m_pClient->m_Snap.m_SpecInfo.m_Active && MaxDistance > 5) // Only multiply mouse coords if not angle bind
 		{
-			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 1000) // Don't scale if it would reduce precision
-				Pos *= length(Pos) * 1000.0f / (float)(g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance);
+			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 500) // Don't scale if it would reduce precision
+				Pos *= length(Pos) * 500.0f / (float)(g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance);
 			if(!g_Config.m_ClOldMouseZoom)
 				Pos *= m_pClient->m_Camera.m_Zoom;
 		}

--- a/src/game/client/components/players.cpp
+++ b/src/game/client/components/players.cpp
@@ -197,8 +197,8 @@ void CPlayers::RenderHookCollLine(
 		const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
 		if(MaxDistance > 5) // Only multiply mouse coords if not angle bind
 		{
-			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 1000) // Don't scale if it would reduce precision
-				Pos *= length(Pos) * 1000.0f / (float)MaxDistance;
+			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 500) // Don't scale if it would reduce precision
+				Pos *= length(Pos) * 500.0f / (float)MaxDistance;
 			if(!m_pClient->m_Snap.m_SpecInfo.m_Active && !g_Config.m_ClOldMouseZoom)
 				Pos *= m_pClient->m_Camera.m_Zoom;
 		}
@@ -480,8 +480,8 @@ void CPlayers::RenderPlayer(
 		const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
 		if(MaxDistance > 5) // Only multiply mouse coords if not angle bind
 		{
-			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 1000) // Don't scale if it would reduce precision
-				Pos *= length(Pos) * 1000.0f / (float)MaxDistance;
+			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 500) // Don't scale if it would reduce precision
+				Pos *= length(Pos) * 500.0f / (float)MaxDistance;
 			if(!m_pClient->m_Snap.m_SpecInfo.m_Active && !g_Config.m_ClOldMouseZoom)
 				Pos *= m_pClient->m_Camera.m_Zoom;
 		}
@@ -920,8 +920,8 @@ void CPlayers::RenderPlayerGhost(
 		const int MaxDistance = g_Config.m_ClDyncam ? g_Config.m_ClDyncamMaxDistance : g_Config.m_ClMouseMaxDistance;
 		if(MaxDistance > 5) // Only multiply mouse coords if not angle bind
 		{
-			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 1000) // Don't scale if it would reduce precision
-				Pos *= length(Pos) * 1000.0f / (float)MaxDistance;
+			if(g_Config.m_ClImproveMousePrecision && MaxDistance < 500) // Don't scale if it would reduce precision
+				Pos *= length(Pos) * 500.0f / (float)MaxDistance;
 			if(!m_pClient->m_Snap.m_SpecInfo.m_Active && !g_Config.m_ClOldMouseZoom)
 				Pos *= m_pClient->m_Camera.m_Zoom;
 		}

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -258,7 +258,7 @@ void CMenus::RenderSettingsTClient(CUIRect MainView)
 		Column.HSplitTop(MarginSmall, nullptr, &Column);
 		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClOldMouseZoom, Localize("Old Mouse Precision (fixes precision at low zoom levels, \nbreaks /tc, /telecursor while zoomed)"), &g_Config.m_ClOldMouseZoom, &Column, LineSize);
 		Column.HSplitTop(MarginSmall, nullptr, &Column);
-		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClImproveMousePrecision, Localize("Improve mouse precision by scaling sent max distance to 1000"), &g_Config.m_ClImproveMousePrecision, &Column, LineSize);
+		DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClImproveMousePrecision, Localize("Improve mouse precision by scaling sent max distance to 500"), &g_Config.m_ClImproveMousePrecision, &Column, LineSize);
 		s_SectionBoxes.back().h = Column.y - s_SectionBoxes.back().y;
 
 		// ***** Anti Latency Tools ***** //


### PR DESCRIPTION
Noby fng bans for "eye follow" when mouse precision turned on. I've been playing with this and haven't gotten banned yet.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
