### PR TITLE
fix: open Discord/GH links in new tab

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -25,12 +25,12 @@
                 <span class="divider"></span>
                 <a href="#download">Download</a>
                 <span class="divider"></span>
-                <a href="https://discord.gg/BgPSapKRkZ" class="discord-link">
+                <a href="https://discord.gg/BgPSapKRkZ" target="_blank" class="discord-link">
                     Discord
                     <img class="discord-icon" src="assets/discord.svg" alt="Discord">
                 </a>
                 <span class="divider"></span>
-                <a href="https://github.com/sjrc6/TaterClient-ddnet" class="discord-link">
+                <a href="https://github.com/sjrc6/TaterClient-ddnet" target="_blank" class="discord-link">
                     GitHub
                     <img class="discord-icon" src="assets/github.svg" alt="GitHub">
                 </a>


### PR DESCRIPTION
After merging this PR, links to Discord/GitHub in top bar gonna open in a new tab