### PR TITLE
Trails alpha multiplied by players' alpha

### DIFF
--- a/src/game/client/components/tclient/trails.cpp
+++ b/src/game/client/components/tclient/trails.cpp
@@ -117,6 +117,12 @@ void CTrails::OnRender()
 		bool LineMode = g_Config.m_ClTeeTrailWidth == 0;
 
 		float Alpha = g_Config.m_ClTeeTrailAlpha / 100.0f;
+		// Taken from players.cpp
+		if(ClientId == -2)
+			Alpha *= g_Config.m_ClRaceGhostAlpha / 100.0f;
+		else if(ClientId < 0 || m_pClient->IsOtherTeam(ClientId))
+			Alpha *= g_Config.m_ClShowOthersAlpha / 100.0f;
+
 		ColorRGBA Col = color_cast<ColorRGBA>(ColorHSLA(g_Config.m_ClTeeTrailColor));
 		if(TeeInfo.m_CustomColoredSkin && g_Config.m_ClTeeTrailUseTeeColor)
 			Col = TeeInfo.m_ColorBody;


### PR DESCRIPTION
Having opaque trails for other teams is distracting, less so with this

## Checklist

- [x] Tested the change ingame
- [x] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
