### PR TITLE
GetWarData returns reference

### DIFF
--- a/src/game/client/components/tclient/warlist.cpp
+++ b/src/game/client/components/tclient/warlist.cpp
@@ -414,7 +414,7 @@ void CWarList::GetReason(char *pReason, int ClientId)
 	str_copy(pReason, m_WarPlayers[ClientId].m_aReason, sizeof(m_WarPlayers[ClientId].m_aReason));
 }
 
-CWarDataCache CWarList::GetWarData(int ClientId)
+CWarDataCache &CWarList::GetWarData(int ClientId)
 {
 	return m_WarPlayers[ClientId];
 }

--- a/src/game/client/components/tclient/warlist.h
+++ b/src/game/client/components/tclient/warlist.h
@@ -194,7 +194,7 @@ public:
 	bool GetClanWar(int ClientId);
 
 	void GetReason(char *pReason, int ClientId);
-	CWarDataCache GetWarData(int ClientId);
+	CWarDataCache &GetWarData(int ClientId);
 
 	void SortWarEntries();
 


### PR DESCRIPTION
GetWarData should return a reference so you can do

`const char* pReason = GetWarData(i).m_pReason`

without it copying the data and creating a dangling ptr

Doesn't change any current behaviour as all uses copy a value then discard the object

```cpp
./game/client/components/nameplates.cpp:		if(g_Config.m_ClWarList && Data.m_IsGame && Data.m_RealClientId >= 0 && !Data.m_ShowClanWarInName && GameClient()->m_WarList.GetWarData(Data.m_RealClientId).IsWarName)
./game/client/components/nameplates.cpp:		else if(g_Config.m_ClWarList && Data.m_IsGame && Data.m_RealClientId >= 0 && Data.m_ShowClanWarInName && GameClient()->m_WarList.GetWarData(Data.m_RealClientId).IsWarClan)
./game/client/components/nameplates.cpp:		if(g_Config.m_ClWarList && Data.m_IsGame && Data.m_RealClientId >= 0 && GameClient()->m_WarList.GetWarData(Data.m_RealClientId).IsWarClan)
./game/client/components/nameplates.cpp:	if(Data.m_IsGame && !Data.m_IsLocal && Data.m_RealClientId >= 0 && g_Config.ms_ClWarList && GameClient()->m_WarList.GetWarData(Data.m_RealClientId).m_aReason[0] != '\0')
./game/client/components/nameplates.cpp:		NamePlate.m_Reason.Update(*this, GameClient()->m_WarList.GetWarData(Data.m_RealClientId).m_aReason, Data.m_FontSizeClan);
./game/client/components/nameplates.cpp:	bool ClanPlateOverride = g_Config.m_ClWarList && g_Config.m_ClWarListShowClan && GameClient()->m_WarList.GetWarData(pPlayerInfo->m_ClientId).IsWarClan;
./game/client/components/nameplates.cpp:	bool ShowClanWarInName = g_Config.m_ClWarList && !ShowClanPlate && GameClient()->m_WarList.GetWarData(pPlayerInfo->m_ClientId).IsWarClan && !GameClient()->m_WarList.GetWarData(pPlayerInfo->m_ClientId).IsWarName;
./game/client/components/tclient/menus_tclient.cpp:		TextRender()->TextColor(GameClient()->m_WarList.GetWarData(i).m_NameColor);
./game/client/components/tclient/menus_tclient.cpp:		TextRender()->TextColor(GameClient()->m_WarList.GetWarData(i).m_ClanColor);
./game/client/components/tclient/player_indicator.cpp:						if(GameClient()->m_WarList.GetWarData(i).m_WarGroupMatches[2])
./game/client/components/tclient/player_indicator.cpp:						if(GameClient()->m_WarList.GetWarData(i).m_WarGroupMatches[1])
```