### PR TITLE
let dbg_assert format the string

### DIFF
--- a/src/base/system.cpp
+++ b/src/base/system.cpp
@@ -1166,9 +1166,7 @@ void net_addr_str(const NETADDR *addr, char *string, int max_length, bool add_po
 	}
 	else
 	{
-		char error[64];
-		str_format(error, sizeof(error), "unknown NETADDR type %d", addr->type);
-		dbg_assert(false, error);
+		dbg_assert(false, "unknown NETADDR type %d", addr->type);
 	}
 }
 

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -165,7 +165,7 @@ void CGraphicsBackend_Threaded::ProcessError(const SGfxErrorContainer &Error)
 		else
 			VerboseStr.append(ErrStr.m_Err);
 	}
-	dbg_assert(false, VerboseStr.c_str());
+	dbg_assert(false, "%s", VerboseStr.c_str());
 }
 
 bool CGraphicsBackend_Threaded::GetWarning(std::vector<std::string> &WarningStrings)


### PR DESCRIPTION
closes #9961

no idea how to approach furo's suggestion, so i left it out.
From what i could tell it would be a redefinition of dbg_assert to enforce using format specifiers? - i could basically copy the style of `str_format_opt` for it i assume, not sure if i should do that here.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
