### PR TITLE
fix checkbox logic

### DIFF
--- a/src/game/client/components/menus.cpp
+++ b/src/game/client/components/menus.cpp
@@ -472,7 +472,7 @@ int CMenus::DoButton_CheckBoxAutoVMarginAndSet(const void *pId, const char *pTex
 	int Logic = DoButton_CheckBox_Common(pId, pText, *pValue ? "X" : "", &CheckBoxRect, BUTTONFLAG_LEFT);
 
 	if(Logic)
-		*pValue ^= 1;
+		*pValue = !*pValue;
 
 	return Logic;
 }


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

Reported by @iMilchshake on discord:
> if you set `tc_hammer_rotates_with_cursor 2` and then use T-Client UI to toggle "Make hammer rotate with cursor" it will toggle between 2 and hiding the hammer :D

This change will ensure checkbox values remain between 0 and 1 upon changing them.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
