### PR TITLE
Fixed `format-security` warning treated as error

### DIFF
--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -4939,7 +4939,7 @@ int main(int argc, const char **argv)
 		{
 			char aError[2048];
 			snprintf(aError, sizeof(aError), "Failed to load config from '%s'.", s_aConfigDomains[ConfigDomain].m_aConfigPath);
-			log_error("client", aError);
+			log_error("client", "%s", aError);
 			pClient->ShowMessageBox("Config File Error", aError);
 			PerformAllCleanup();
 			return -1;


### PR DESCRIPTION
<!-- What is the motivation for the changes of this pull request? -->

This pull request avoids the following error when building the project with Nix (the used version is https://github.com/sjrc6/TaterClient-ddnet/tree/V10.3.0).
```
       > /nix/store/0fsnicvfpf55nkza12cjnad0w84d6ba7-gcc-wrapper-14.2.1.20250322/bin/g++ -DCONF_BACKEND_VULKAN -DCONF_INFORM_UPDATE -DCONF_OPENSSL -DCONF_VIDEORECORDER -DCONF_WAVPACK_CLOSE_FILE -DCONF_WAVPACK_OPEN_FILE_INPUT_EX -DGLEW_STATIC -D_FILE_OFFSET_BITS=64 -D_FORTIFY_SOURCE=2 -I/build/source/build/src -I/build/source/src -I/build/source/src/rust-bridge -isystem /nix/store/4cfzs10xfawx5c2xrgywgm4zlgkjzfbn-freetype-2.13.3-dev/include/freetype2 -isystem /nix/store/1dakjk5zfb81f0nqc6rmkldrmd8gg04z-opusfile-0.12-dev/include/opus -isystem /nix/store/hqcn14wxbszrq3w4vcvqs38d32ll0lz7-libopus-1.5.2-dev/include/opus -isystem /nix/store/s7f0ckw8pa6yap3a7kbn01lwy4s2a2gc-sdl2-compat-2.32.56-dev/include/SDL2 -isystem /nix/store/283xxjjjmx6fph3p0n6ayf2b087n7fi2-wavpack-5.8.1-dev/include/wavpack -isystem /nix/store/l5szgijqaykv8yry7agr1ylpza3mp5z0-gdk-pixbuf-2.42.12-dev/include/gdk-pixbuf-2.0 -isystem /nix/store/h181byhbm1sw49r449krkyj3a0n0ins2-glib-2.84.1-dev/include/glib-2.0 -isystem /nix/store/bkpj51fz88rbyjd60i6lrp0xdax1b24g-glib-2.84.1/lib/glib-2.0/include -O3 -DNDEBUG -std=c++17 -fdiagnostics-color=always -fstack-protector-strong -fno-exceptions -fsigned-char -Wall -Wextra -Wno-psabi -Wno-unused-parameter -Wno-missing-field-initializers -Wno-nullability-completeness -Wduplicated-cond -Wduplicated-branches -Wlogical-op -Wrestrict -Wshadow=global -Wsuggest-override -Wclass-memaccess -MD -MT CMakeFiles/game-client.dir/src/engine/client/client.cpp.o -MF CMakeFiles/game-client.dir/src/engine/client/client.cpp.o.d -o CMakeFiles/game-client.dir/src/engine/client/client.cpp.o -c /build/source/src/engine/client/client.cpp
       > In file included from /build/source/src/engine/client/client.cpp:6:
       > /build/source/src/engine/client/client.cpp: In function 'int main(int, const char**)':
       > /build/source/src/engine/client/client.cpp:4936:45: error: format not a string literal and no format arguments [-Werror=format-security]
       >  4936 |                         log_error("client", aError);
       >       |                                             ^~~~~~
       > /build/source/src/base/log.h:29:55: note: in definition of macro 'log_error'
       >    29 | #define log_error(sys, ...) log_log(LEVEL_ERROR, sys, __VA_ARGS__)
       >       |                                                       ^~~~~~~~~~~
       > At global scope:
       > cc1plus: note: unrecognized command-line option '-Wno-nullability-completeness' may have been intended to silence earlier diagnostics
       > cc1plus: some warnings being treated as errors
       > [122/256] Building CXX object CMakeFiles/game-client.dir/src/engine/client/sound.cpp.o
       > [123/256] Building CXX object CMakeFiles/game-client.dir/src/engine/client/graphics_threaded.cpp.o
       > [124/256] Building CXX object CMakeFiles/game-client.dir/src/engine/client/updater.cpp.o
       > [125/256] Building CXX object CMakeFiles/game-client.dir/src/engine/client/video.cpp.o
       > [126/256] Building CXX object CMakeFiles/game-client.dir/src/engine/client/serverbrowser.cpp.o
       > [127/256] Building CXX object CMakeFiles/game-client.dir/src/engine/client/text.cpp.o
       > [128/256] Building CXX object CMakeFiles/game-client.dir/src/engine/client/backend/vulkan/backend_vulkan.cpp.o
       > ninja: build stopped: subcommand failed.
```

Also, see the nixpkgs PR https://github.com/NixOS/nixpkgs/pull/410490.

<!-- Note that builds and other checks will be run for your change. Don't feel intimidated by failures in some of the checks. If you can't resolve them yourself, experienced devs can also resolve them before merging your pull request. -->

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
