### PR TITLE
Allow empty clan in profile to overwrite current clan

### DIFF
--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -139,7 +139,7 @@ MACRO_CONFIG_INT(ClApplyProfileClan, tc_profile_clan, 0, 0, 1, CFGFLAG_CLIENT | 
 MACRO_CONFIG_INT(ClApplyProfileFlag, tc_profile_flag, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply flag in profiles")
 MACRO_CONFIG_INT(ClApplyProfileColors, tc_profile_colors, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply colors in profiles")
 MACRO_CONFIG_INT(ClApplyProfileEmote, tc_profile_emote, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply emote in profiles")
-MACRO_CONFIG_INT(ClAllowEmptyClan, tc_profile_allow_empty_clan, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Overwrite clan name even if profile has an empty clan name")
+MACRO_CONFIG_INT(ClProfileOverwriteClanWithEmpty, tc_profile_overwrite_clan_with_empty, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Overwrite clan name even if profile has an empty clan name")
 
 // Rainbow
 MACRO_CONFIG_INT(ClRainbowTees, tc_rainbow_tees, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Turn on rainbow client side")

--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -139,7 +139,7 @@ MACRO_CONFIG_INT(ClApplyProfileClan, tc_profile_clan, 0, 0, 1, CFGFLAG_CLIENT | 
 MACRO_CONFIG_INT(ClApplyProfileFlag, tc_profile_flag, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply flag in profiles")
 MACRO_CONFIG_INT(ClApplyProfileColors, tc_profile_colors, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply colors in profiles")
 MACRO_CONFIG_INT(ClApplyProfileEmote, tc_profile_emote, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply emote in profiles")
-MACRO_CONFIG_INT(ClAllowEmptyValues, tc_profile_allow_empty, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Allow empty values in profiles")
+MACRO_CONFIG_INT(ClAllowEmptyClan, tc_profile_allow_empty_clan, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Overwrite clan name even if profile has an empty clan name")
 
 // Rainbow
 MACRO_CONFIG_INT(ClRainbowTees, tc_rainbow_tees, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Turn on rainbow client side")

--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -139,6 +139,7 @@ MACRO_CONFIG_INT(ClApplyProfileClan, tc_profile_clan, 0, 0, 1, CFGFLAG_CLIENT | 
 MACRO_CONFIG_INT(ClApplyProfileFlag, tc_profile_flag, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply flag in profiles")
 MACRO_CONFIG_INT(ClApplyProfileColors, tc_profile_colors, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply colors in profiles")
 MACRO_CONFIG_INT(ClApplyProfileEmote, tc_profile_emote, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Apply emote in profiles")
+MACRO_CONFIG_INT(ClAllowEmptyValues, tc_profile_allow_empty, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Allow empty values in profiles")
 
 // Rainbow
 MACRO_CONFIG_INT(ClRainbowTees, tc_rainbow_tees, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Turn on rainbow client side")

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -1920,7 +1920,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 		MainView.HSplitTop(50.0f, &Label, &MainView);
 		Label.VSplitLeft(250.0f, &Label, nullptr);
 
-		if(DoSkin && strlen(LoadProfile.m_SkinName) != 0)
+		if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0) || g_Config.m_ClAllowEmptyValues)
 		{
 			const CSkin *pLoadSkin = m_pClient->m_Skins.Find(LoadProfile.m_SkinName);
 			OwnSkinInfo.m_OriginalRenderSkin = pLoadSkin->m_OriginalSkin;
@@ -1942,7 +1942,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 
 		if(DoName && strlen(LoadProfile.m_Name) != 0)
 			str_format(aName, sizeof(aName), "%s", LoadProfile.m_Name);
-		if(DoClan)
+		if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyValues))
 			str_format(aClan, sizeof(aClan), "%s", LoadProfile.m_Clan);
 
 		Label.VSplitLeft(90.0f, &FlagRect, &Label);
@@ -1956,7 +1956,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 		Ui()->DoLabel(&Section, aTempBuf, FontSize, TEXTALIGN_ML);
 
 		Label.HSplitTop(LineSize, &Section, &Label);
-		str_format(aTempBuf, sizeof(aTempBuf), TCLocalize("Skin: %s"), (DoSkin && strlen(LoadProfile.m_SkinName) != 0) ? LoadProfile.m_SkinName : pSkinName);
+		str_format(aTempBuf, sizeof(aTempBuf), TCLocalize("Skin: %s"), (DoSkin && (strlen(LoadProfile.m_SkinName) != 0) || g_Config.m_ClAllowEmptyValues) ? LoadProfile.m_SkinName : pSkinName);
 		Ui()->DoLabel(&Section, aTempBuf, FontSize, TEXTALIGN_ML);
 
 		FlagRect.VSplitRight(50.0f, nullptr, &FlagRect);
@@ -2003,6 +2003,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileName, TCLocalize("Save/Load Name"), &g_Config.m_ClApplyProfileName, &LabelMid, LineSize);
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileClan, TCLocalize("Save/Load Clan"), &g_Config.m_ClApplyProfileClan, &LabelMid, LineSize);
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileFlag, TCLocalize("Save/Load Flag"), &g_Config.m_ClApplyProfileFlag, &LabelMid, LineSize);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClAllowEmptyValues, TCLocalize("Load Empty Values"), &g_Config.m_ClAllowEmptyValues, &LabelMid, LineSize);
 
 	CUIRect Button;
 	LabelRight.VSplitLeft(150.0f, &LabelRight, nullptr);
@@ -2017,7 +2018,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 			CProfile LoadProfile = GameClient()->m_SkinProfiles.m_Profiles[s_SelectedProfile];
 			if(!m_Dummy)
 			{
-				if(DoSkin && strlen(LoadProfile.m_SkinName) != 0)
+				if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValues))
 					str_copy(g_Config.m_ClPlayerSkin, LoadProfile.m_SkinName, sizeof(g_Config.m_ClPlayerSkin));
 				if(DoColors && LoadProfile.m_BodyColor != -1 && LoadProfile.m_FeetColor != -1)
 				{
@@ -2028,14 +2029,14 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 					g_Config.m_ClPlayerDefaultEyes = LoadProfile.m_Emote;
 				if(DoName && strlen(LoadProfile.m_Name) != 0)
 					str_copy(g_Config.m_PlayerName, LoadProfile.m_Name, sizeof(g_Config.m_PlayerName));
-				if(DoClan)
+				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyValues))
 					str_copy(g_Config.m_PlayerClan, LoadProfile.m_Clan, sizeof(g_Config.m_PlayerClan));
 				if(DoFlag && LoadProfile.m_CountryFlag != -2)
 					g_Config.m_PlayerCountry = LoadProfile.m_CountryFlag;
 			}
 			else
 			{
-				if(DoSkin && strlen(LoadProfile.m_SkinName) != 0)
+				if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValues))
 					str_copy(g_Config.m_ClDummySkin, LoadProfile.m_SkinName, sizeof(g_Config.m_ClDummySkin));
 				if(DoColors && LoadProfile.m_BodyColor != -1 && LoadProfile.m_FeetColor != -1)
 				{
@@ -2046,7 +2047,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 					g_Config.m_ClDummyDefaultEyes = LoadProfile.m_Emote;
 				if(DoName && strlen(LoadProfile.m_Name) != 0)
 					str_copy(g_Config.m_ClDummyName, LoadProfile.m_Name, sizeof(g_Config.m_ClDummyName));
-				if(DoClan)
+				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyValues))
 					str_copy(g_Config.m_ClDummyClan, LoadProfile.m_Clan, sizeof(g_Config.m_ClDummyClan));
 				if(DoFlag && LoadProfile.m_CountryFlag != -2)
 					g_Config.m_ClDummyCountry = LoadProfile.m_CountryFlag;

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -1920,7 +1920,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 		MainView.HSplitTop(50.0f, &Label, &MainView);
 		Label.VSplitLeft(250.0f, &Label, nullptr);
 
-		if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0) || g_Config.m_ClAllowEmptyValues)
+if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValues))
 		{
 			const CSkin *pLoadSkin = m_pClient->m_Skins.Find(LoadProfile.m_SkinName);
 			OwnSkinInfo.m_OriginalRenderSkin = pLoadSkin->m_OriginalSkin;

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -2029,7 +2029,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 					g_Config.m_ClPlayerDefaultEyes = LoadProfile.m_Emote;
 				if(DoName && strlen(LoadProfile.m_Name) != 0)
 					str_copy(g_Config.m_PlayerName, LoadProfile.m_Name, sizeof(g_Config.m_PlayerName));
-				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyClan))
+				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClProfileOverwriteClanWithEmpty))
 					str_copy(g_Config.m_PlayerClan, LoadProfile.m_Clan, sizeof(g_Config.m_PlayerClan));
 				if(DoFlag && LoadProfile.m_CountryFlag != -2)
 					g_Config.m_PlayerCountry = LoadProfile.m_CountryFlag;

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -1920,7 +1920,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 		MainView.HSplitTop(50.0f, &Label, &MainView);
 		Label.VSplitLeft(250.0f, &Label, nullptr);
 
-if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValues))
+		if(DoSkin && strlen(LoadProfile.m_SkinName) != 0)
 		{
 			const CSkin *pLoadSkin = m_pClient->m_Skins.Find(LoadProfile.m_SkinName);
 			OwnSkinInfo.m_OriginalRenderSkin = pLoadSkin->m_OriginalSkin;
@@ -1942,7 +1942,7 @@ if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValu
 
 		if(DoName && strlen(LoadProfile.m_Name) != 0)
 			str_format(aName, sizeof(aName), "%s", LoadProfile.m_Name);
-		if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyValues))
+		if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyClan))
 			str_format(aClan, sizeof(aClan), "%s", LoadProfile.m_Clan);
 
 		Label.VSplitLeft(90.0f, &FlagRect, &Label);
@@ -1956,7 +1956,7 @@ if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValu
 		Ui()->DoLabel(&Section, aTempBuf, FontSize, TEXTALIGN_ML);
 
 		Label.HSplitTop(LineSize, &Section, &Label);
-		str_format(aTempBuf, sizeof(aTempBuf), TCLocalize("Skin: %s"), (DoSkin && (strlen(LoadProfile.m_SkinName) != 0) || g_Config.m_ClAllowEmptyValues) ? LoadProfile.m_SkinName : pSkinName);
+		str_format(aTempBuf, sizeof(aTempBuf), TCLocalize("Skin: %s"), (DoSkin && strlen(LoadProfile.m_SkinName) != 0) ? LoadProfile.m_SkinName : pSkinName);
 		Ui()->DoLabel(&Section, aTempBuf, FontSize, TEXTALIGN_ML);
 
 		FlagRect.VSplitRight(50.0f, nullptr, &FlagRect);
@@ -2003,7 +2003,7 @@ if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValu
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileName, TCLocalize("Save/Load Name"), &g_Config.m_ClApplyProfileName, &LabelMid, LineSize);
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileClan, TCLocalize("Save/Load Clan"), &g_Config.m_ClApplyProfileClan, &LabelMid, LineSize);
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileFlag, TCLocalize("Save/Load Flag"), &g_Config.m_ClApplyProfileFlag, &LabelMid, LineSize);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClAllowEmptyValues, TCLocalize("Load Empty Values"), &g_Config.m_ClAllowEmptyValues, &LabelMid, LineSize);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClAllowEmptyClan, TCLocalize("Overwrite clan even if empty"), &g_Config.m_ClAllowEmptyClan, &LabelMid, LineSize);
 
 	CUIRect Button;
 	LabelRight.VSplitLeft(150.0f, &LabelRight, nullptr);
@@ -2018,7 +2018,7 @@ if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValu
 			CProfile LoadProfile = GameClient()->m_SkinProfiles.m_Profiles[s_SelectedProfile];
 			if(!m_Dummy)
 			{
-				if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValues))
+				if(DoSkin && strlen(LoadProfile.m_SkinName) != 0)
 					str_copy(g_Config.m_ClPlayerSkin, LoadProfile.m_SkinName, sizeof(g_Config.m_ClPlayerSkin));
 				if(DoColors && LoadProfile.m_BodyColor != -1 && LoadProfile.m_FeetColor != -1)
 				{
@@ -2029,14 +2029,14 @@ if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValu
 					g_Config.m_ClPlayerDefaultEyes = LoadProfile.m_Emote;
 				if(DoName && strlen(LoadProfile.m_Name) != 0)
 					str_copy(g_Config.m_PlayerName, LoadProfile.m_Name, sizeof(g_Config.m_PlayerName));
-				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyValues))
+				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyClan))
 					str_copy(g_Config.m_PlayerClan, LoadProfile.m_Clan, sizeof(g_Config.m_PlayerClan));
 				if(DoFlag && LoadProfile.m_CountryFlag != -2)
 					g_Config.m_PlayerCountry = LoadProfile.m_CountryFlag;
 			}
 			else
 			{
-				if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValues))
+				if(DoSkin && strlen(LoadProfile.m_SkinName) != 0)
 					str_copy(g_Config.m_ClDummySkin, LoadProfile.m_SkinName, sizeof(g_Config.m_ClDummySkin));
 				if(DoColors && LoadProfile.m_BodyColor != -1 && LoadProfile.m_FeetColor != -1)
 				{
@@ -2047,7 +2047,7 @@ if(DoSkin && (strlen(LoadProfile.m_SkinName) != 0 || g_Config.m_ClAllowEmptyValu
 					g_Config.m_ClDummyDefaultEyes = LoadProfile.m_Emote;
 				if(DoName && strlen(LoadProfile.m_Name) != 0)
 					str_copy(g_Config.m_ClDummyName, LoadProfile.m_Name, sizeof(g_Config.m_ClDummyName));
-				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyValues))
+				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyClan))
 					str_copy(g_Config.m_ClDummyClan, LoadProfile.m_Clan, sizeof(g_Config.m_ClDummyClan));
 				if(DoFlag && LoadProfile.m_CountryFlag != -2)
 					g_Config.m_ClDummyCountry = LoadProfile.m_CountryFlag;

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -1942,7 +1942,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 
 		if(DoName && strlen(LoadProfile.m_Name) != 0)
 			str_format(aName, sizeof(aName), "%s", LoadProfile.m_Name);
-		if(DoClan && strlen(LoadProfile.m_Clan) != 0)
+		if(DoClan)
 			str_format(aClan, sizeof(aClan), "%s", LoadProfile.m_Clan);
 
 		Label.VSplitLeft(90.0f, &FlagRect, &Label);
@@ -2028,7 +2028,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 					g_Config.m_ClPlayerDefaultEyes = LoadProfile.m_Emote;
 				if(DoName && strlen(LoadProfile.m_Name) != 0)
 					str_copy(g_Config.m_PlayerName, LoadProfile.m_Name, sizeof(g_Config.m_PlayerName));
-				if(DoClan && strlen(LoadProfile.m_Clan) != 0)
+				if(DoClan)
 					str_copy(g_Config.m_PlayerClan, LoadProfile.m_Clan, sizeof(g_Config.m_PlayerClan));
 				if(DoFlag && LoadProfile.m_CountryFlag != -2)
 					g_Config.m_PlayerCountry = LoadProfile.m_CountryFlag;
@@ -2046,7 +2046,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 					g_Config.m_ClDummyDefaultEyes = LoadProfile.m_Emote;
 				if(DoName && strlen(LoadProfile.m_Name) != 0)
 					str_copy(g_Config.m_ClDummyName, LoadProfile.m_Name, sizeof(g_Config.m_ClDummyName));
-				if(DoClan && strlen(LoadProfile.m_Clan) != 0)
+				if(DoClan)
 					str_copy(g_Config.m_ClDummyClan, LoadProfile.m_Clan, sizeof(g_Config.m_ClDummyClan));
 				if(DoFlag && LoadProfile.m_CountryFlag != -2)
 					g_Config.m_ClDummyCountry = LoadProfile.m_CountryFlag;

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -2003,7 +2003,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileName, TCLocalize("Save/Load Name"), &g_Config.m_ClApplyProfileName, &LabelMid, LineSize);
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileClan, TCLocalize("Save/Load Clan"), &g_Config.m_ClApplyProfileClan, &LabelMid, LineSize);
 	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClApplyProfileFlag, TCLocalize("Save/Load Flag"), &g_Config.m_ClApplyProfileFlag, &LabelMid, LineSize);
-	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClAllowEmptyClan, TCLocalize("Overwrite clan even if empty"), &g_Config.m_ClAllowEmptyClan, &LabelMid, LineSize);
+	DoButton_CheckBoxAutoVMarginAndSet(&g_Config.m_ClAllowEmptyClan, TCLocalize("Overwrite clan even if empty"), &g_Config.m_ClProfileOverwriteClanWithEmpty, &LabelMid, LineSize);
 
 	CUIRect Button;
 	LabelRight.VSplitLeft(150.0f, &LabelRight, nullptr);

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -1942,7 +1942,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 
 		if(DoName && strlen(LoadProfile.m_Name) != 0)
 			str_format(aName, sizeof(aName), "%s", LoadProfile.m_Name);
-		if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyClan))
+		if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClProfileOverwriteClanWithEmpty))
 			str_format(aClan, sizeof(aClan), "%s", LoadProfile.m_Clan);
 
 		Label.VSplitLeft(90.0f, &FlagRect, &Label);

--- a/src/game/client/components/tclient/menus_tclient.cpp
+++ b/src/game/client/components/tclient/menus_tclient.cpp
@@ -2047,7 +2047,7 @@ void CMenus::RenderSettingsProfiles(CUIRect MainView)
 					g_Config.m_ClDummyDefaultEyes = LoadProfile.m_Emote;
 				if(DoName && strlen(LoadProfile.m_Name) != 0)
 					str_copy(g_Config.m_ClDummyName, LoadProfile.m_Name, sizeof(g_Config.m_ClDummyName));
-				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClAllowEmptyClan))
+				if(DoClan && (strlen(LoadProfile.m_Clan) != 0 || g_Config.m_ClProfileOverwriteClanWithEmpty))
 					str_copy(g_Config.m_ClDummyClan, LoadProfile.m_Clan, sizeof(g_Config.m_ClDummyClan));
 				if(DoFlag && LoadProfile.m_CountryFlag != -2)
 					g_Config.m_ClDummyCountry = LoadProfile.m_CountryFlag;


### PR DESCRIPTION
When someone wants change to a name without a clan, they have to manually delete the clan after loading the profile. This changes makes it possible to load a profile with an empty "clan" field.

## Checklist

- [x] Tested the change ingame
- [x] Changed no physics that affect existing maps
