### PR TITLE
Add option to write crash dump on unhandled exception on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2338,6 +2338,8 @@ if(CLIENT)
     checksum.h
     client.cpp
     client.h
+    crash_handler.cpp
+    crash_handler.h
     demoedit.cpp
     demoedit.h
     discord.cpp

--- a/src/engine/client/client.cpp
+++ b/src/engine/client/client.cpp
@@ -57,6 +57,7 @@
 #include "friends.h"
 #include "notifications.h"
 #include "serverbrowser.h"
+#include "crash_handler.h"
 
 #if defined(CONF_VIDEORECORDER)
 #include "video.h"
@@ -4931,6 +4932,12 @@ int main(int argc, const char **argv)
 		}
 	}
 	g_Config.m_ClConfigVersion = 1;
+
+#if defined(CONF_FAMILY_WINDOWS)
+	if (g_Config.m_ClWriteCrashDump > 0) {
+		InitCrashHandler(g_Config.m_ClWriteCrashDump == 2);
+	}
+#endif
 
 	// parse the command line arguments
 	pConsole->SetUnknownCommandCallback(UnknownArgumentCallback, pClient);

--- a/src/engine/client/crash_handler.cpp
+++ b/src/engine/client/crash_handler.cpp
@@ -1,0 +1,99 @@
+#include "crash_handler.h"
+
+#include <base/detect.h>
+
+#if defined(CONF_FAMILY_WINDOWS)
+#include <windows.h>
+#include <dbghelp.h>
+#include <tchar.h>
+#include <iostream>
+#include <sstream>
+#include <iomanip>
+#include <string>
+
+#pragma comment(lib, "dbghelp.lib")
+#endif
+
+namespace
+{
+bool g_useFullMemoryDump = false;
+}
+
+#if defined(CONF_FAMILY_WINDOWS)
+static LPTOP_LEVEL_EXCEPTION_FILTER g_prevExceptionFilter = nullptr;
+
+std::wstring getExecutableName()
+{
+    wchar_t path[MAX_PATH];
+    GetModuleFileNameW(NULL, path, MAX_PATH);
+    std::wstring fullPath(path);
+    size_t pos = fullPath.find_last_of(L"\\/");
+    return (pos != std::wstring::npos) ? fullPath.substr(pos + 1) : fullPath;
+}
+
+std::wstring GenerateDumpFilename()
+{
+    SYSTEMTIME st;
+    GetLocalTime(&st);
+
+    std::wostringstream oss;
+    oss << getExecutableName()
+        << L"_"
+        << st.wYear << L"-"
+        << std::setw(2) << std::setfill(L'0') << st.wMonth << L"-"
+        << std::setw(2) << std::setfill(L'0') << st.wDay << L"_"
+        << std::setw(2) << std::setfill(L'0') << st.wHour << L"-"
+        << std::setw(2) << std::setfill(L'0') << st.wMinute << L"-"
+        << std::setw(2) << std::setfill(L'0') << st.wSecond;
+
+    if (g_useFullMemoryDump)
+        oss << L"_full";
+
+    oss << L".dmp";
+
+    return oss.str();
+}
+
+LONG WINAPI UnhandledExceptionHandler(EXCEPTION_POINTERS* pExceptionPointers)
+{
+    std::wstring dumpFilename = GenerateDumpFilename();
+
+    HANDLE hFile = CreateFileW(dumpFilename.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+    if (hFile != INVALID_HANDLE_VALUE) {
+        MINIDUMP_EXCEPTION_INFORMATION mdei;
+        mdei.ThreadId = GetCurrentThreadId();
+        mdei.ExceptionPointers = pExceptionPointers;
+        mdei.ClientPointers = FALSE;
+
+        MINIDUMP_TYPE dumpType = g_useFullMemoryDump
+            ? MiniDumpWithFullMemory
+            : MiniDumpNormal;
+
+        BOOL result = MiniDumpWriteDump(
+            GetCurrentProcess(),
+            GetCurrentProcessId(),
+            hFile,
+            dumpType,
+            &mdei,
+            nullptr,
+            nullptr
+        );
+
+        CloseHandle(hFile);
+    }
+
+    if (g_prevExceptionFilter)
+        return g_prevExceptionFilter(pExceptionPointers);
+
+    return EXCEPTION_EXECUTE_HANDLER;
+}
+
+void InitCrashHandler(bool full)
+{
+    g_useFullMemoryDump = full;
+    g_prevExceptionFilter = SetUnhandledExceptionFilter(UnhandledExceptionHandler);
+}
+#else
+void InitCrashHandler(bool full) {}
+#endif

--- a/src/engine/client/crash_handler.h
+++ b/src/engine/client/crash_handler.h
@@ -1,0 +1,6 @@
+#ifndef ENGINE_CLIENT_CRASH_HANDLER_H
+#define ENGINE_CLIENT_CRASH_HANDLER_H
+
+void InitCrashHandler(bool full);
+
+#endif

--- a/src/engine/shared/config_variables_tclient.h
+++ b/src/engine/shared/config_variables_tclient.h
@@ -238,3 +238,7 @@ MACRO_CONFIG_INT(ClTClientSettingsTabs, tc_tclient_settings_tabs, 0, 0, 65536, C
 // Mod
 MACRO_CONFIG_INT(ClShowPlayerHitBoxes, tc_show_player_hit_boxes, 0, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show player hit boxes (1 = predicted, 2 = predicted and unpredicted)")
 MACRO_CONFIG_INT(ClHideChatBubbles, tc_hide_chat_bubbles, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Hide your own chat bubbles, only works when authed in remote console")
+
+#if defined(CONF_FAMILY_WINDOWS)
+MACRO_CONFIG_INT(ClWriteCrashDump, tc_write_crash_dump, 0, 0, 2, CFGFLAG_SAVE | CFGFLAG_CLIENT, "Whether to write a crash dump on crash (0 = off, 1 = on/normal, 2 = full")
+#endif


### PR DESCRIPTION
While thinking about #57, I remembered that its possible to write `*.dmp` when an unhandled exception occurs. This adds a setting for windows users, that controls if a dump is written or not.

If the exe was built with debug infos (`RelWithDebInfo`), the dump can be loaded together with the corresponding `*.pdb` file in WinDbg, which can then be used to further analyze the dump.

## Checklist

- [x] Tested the change ingame
- [x] Changed no physics that affect existing maps
