### PR TITLE
Fix bool comparison

### DIFF
--- a/src/game/client/components/tclient/webhook.cpp
+++ b/src/game/client/components/tclient/webhook.cpp
@@ -110,7 +110,7 @@ void CWebhook::OnRender()
 		return;
 	m_TimeSinceLastRequest += Client()->RenderFrameTime();
 	m_TimeSinceBufferStart += Client()->RenderFrameTime();
-	if(m_TimeSinceLastRequest >= Client()->RconAuthed() ? BUFFER_MIN_TIME_AUTHED : BUFFER_MIN_TIME)
+	if(m_TimeSinceLastRequest >= (Client()->RconAuthed() ? BUFFER_MIN_TIME_AUTHED : BUFFER_MIN_TIME))
 		FlushBuffer();
 	if(m_TimeSinceBufferStart >= BUFFER_MAX_TIME)
 		FlushBuffer();


### PR DESCRIPTION
```
   voting.cpp
D:\a\TaterClient-ddnet\TaterClient-ddnet\src\game\client\components\tclient\webhook.cpp(113,5): error C2220: the following warning is treated as an error [D:\a\TaterClient-ddnet\TaterClient-ddnet\debug\game-client.vcxproj]
D:\a\TaterClient-ddnet\TaterClient-ddnet\src\game\client\components\tclient\webhook.cpp(113,5): warning C4804: '>=': unsafe use of type 'bool' in operation [D:\a\TaterClient-ddnet\TaterClient-ddnet\debug\game-client.vcxproj]
  gameclient.cpp
```
