### PR TITLE
feat: Add team invite button (to scoreboard)

### DIFF
--- a/src/game/client/components/scoreboard.h
+++ b/src/game/client/components/scoreboard.h
@@ -37,6 +37,10 @@ class CScoreboard : public CComponent
 	void UpdateTeamStateTracking();
 	void ResetInviteState(int ClientId = -1);
 	bool IsGlobalInviteCooldownActive() const;
+	bool IsServerJoinCooldownActive() const;
+	bool IsLocalPlayerInActiveRun() const;
+	bool IsLocalPlayerFrozen() const;
+	bool ShouldDisableInteraction() const;
 	int FindNextEmptyTeam() const;
 
 	float m_InviteButtonWidth;
@@ -49,6 +53,8 @@ class CScoreboard : public CComponent
 	bool m_InAutoJoinSequence;
 
 	bool m_aPlayerWasActive[64];
+	
+	int64_t m_ServerJoinTime;
 
 	bool m_MouseModeWasAbsolute;
 


### PR DESCRIPTION
Features:
- Interactive invite buttons in scoreboard for each player
- Auto-join functionality for TEAM_FLOCK players (join empty team + lock + invite)
- Normal invite functionality for players already on teams
- Mouse cursor support in scoreboard for button interaction
- Visual feedback (checkmarks, cooldowns, disabled states)
- State tracking and cooldown management
- Automatic cleanup when players leave/join

Files modified:
- src/game/client/components/scoreboard.h: Added invite button methods and member variables
- src/game/client/components/scoreboard.cpp: Added full invite button implementation

Automates the tedious process of joining team, locking it, and inviting players (especially those with special characters in name).

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
