### PR TITLE
Fix: Wayland 4:3 resolution support

### DIFF
--- a/src/engine/client/backend/vulkan/backend_vulkan.cpp
+++ b/src/engine/client/backend/vulkan/backend_vulkan.cpp
@@ -4055,12 +4055,21 @@ public:
 
 		VkExtent2D AutoViewportExtent = RetSize;
 		bool UsesForcedViewport = false;
+#ifdef CONF_FAMILY_WINDOWS
 		// keep this in sync with graphics_threaded AdjustViewport's check
 		if(AutoViewportExtent.height > 4 * AutoViewportExtent.width / 5 && g_GraphicsForcedAspect)
 		{
 			AutoViewportExtent.height = 4 * AutoViewportExtent.width / 5;
 			UsesForcedViewport = true;
 		}
+
+#else
+		if(AutoViewportExtent.height > 3 * AutoViewportExtent.width / 4)
+		{
+			AutoViewportExtent.height = 3 * AutoViewportExtent.width / 4;
+			UsesForcedViewport = true;
+		}
+#endif
 
 		SSwapImgViewportExtent Ext;
 		Ext.m_SwapImageViewport = RetSize;

--- a/src/engine/client/backend_sdl.cpp
+++ b/src/engine/client/backend_sdl.cpp
@@ -1144,8 +1144,7 @@ int CGraphicsBackend_SDL_GL::Init(const char *pName, int *pScreen, int *pWidth, 
 #if CONF_PLATFORM_LINUX && SDL_VERSION_ATLEAST(2, 0, 22)
 		// needed to workaround SDL from forcing exclusively X11 if linking against the GLX flavour of GLEW instead of the EGL one
 		// w/o this on Wayland systems (no XWayland support) SDL's Video subsystem will fail to load (starting from SDL2.30+)
-		if(Linked.major == 2 && Linked.minor >= 30)
-			SDL_SetHint(SDL_HINT_VIDEODRIVER, "x11,wayland");
+			SDL_SetHintWithPriority(SDL_HINT_VIDEODRIVER, "wayland,x11", SDL_HINT_OVERRIDE);
 #endif
 	}
 

--- a/src/engine/client/graphics_threaded.cpp
+++ b/src/engine/client/graphics_threaded.cpp
@@ -2263,6 +2263,7 @@ void CGraphics_Threaded::SetForcedAspect(bool Force)
 
 void CGraphics_Threaded::AdjustViewport(bool SendViewportChangeToBackend)
 {
+#ifdef CONF_FAMILY_WINDOWS
 	// adjust the viewport to only allow certain aspect ratios
 	// keep this in sync with backend_vulkan GetSwapImageSize's check
 	if(m_ScreenHeight > 4 * m_ScreenWidth / 5 && g_GraphicsForcedAspect)
@@ -2279,6 +2280,24 @@ void CGraphics_Threaded::AdjustViewport(bool SendViewportChangeToBackend)
 	{
 		m_IsForcedViewport = false;
 	}
+
+#else
+	if(m_ScreenHeight > 3 * m_ScreenWidth / 4)
+	{
+		m_IsForcedViewport = true;
+		m_ScreenHeight = 3 * m_ScreenWidth / 4;
+
+		if(SendViewportChangeToBackend)
+		{
+			UpdateViewport(0, 0, m_ScreenWidth, m_ScreenHeight, true);
+		}
+	}
+	else
+	{
+		m_IsForcedViewport = false;
+	}
+#endif
+
 }
 
 void CGraphics_Threaded::UpdateViewport(int X, int Y, int W, int H, bool ByResize)


### PR DESCRIPTION
To clarify, the main reason for this PR isn’t just about 4:3 support. On Wayland, I found that practically no resolution was working properly without bugging out or failing to start entirely. 

Before these changes, I could only get a stable experience on native 1080p. This PR actually sorts out the scaling issues across the board for Wayland environments, ensuring that all resolutions now work smoothly without the usual bugs.

[ A quick note on the SDL_HINT_VIDEODRIVER change: I added this because I was seeing some flickering and inconsistent window initialization on startup under Wayland. Forcing this hint seems to settle the driver down and keeps the window behavior predictable. ]

Tested on:
- OS: Arch Linux
- DE: KDE Plasma 6.5.4
- GPU: RTX 3080 (Nvidia)