### PR TITLE
Load community cache before serverbrowser uses it

### DIFF
--- a/src/game/client/components/tclient/custom_communities.cpp
+++ b/src/game/client/components/tclient/custom_communities.cpp
@@ -90,6 +90,9 @@ void CCustomCommunities::OnInit()
 
 void CCustomCommunities::OnConsoleInit()
 {
+	// Load Custom Communities from the file before the serverbrowser tries to use it
+	LoadCustomCommunitiesDDNetInfo();
+
 	Console()->Chain(
 		"tc_custom_communities_url", [](IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData) {
 			pfnCallback(pResult, pCallbackUserData);


### PR DESCRIPTION
I've been using this on my client and it's been working, haven't had any issues

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [ ] I didn't use generative AI to generate more than single-line completions
- [x] Don't care about checkboxes
