### PR TITLE
Don't clean filters if custom communities haven't loaded

### DIFF
--- a/src/engine/client/serverbrowser.cpp
+++ b/src/engine/client/serverbrowser.cpp
@@ -2347,7 +2347,7 @@ void CExcludedCommunityTypeFilterList::Save(IConfigManager *pConfigManager) cons
 void CServerBrowser::CleanFilters()
 {
 	// Keep filters if we failed to load any communities
-	if(Communities().empty())
+	if(Communities().empty() || !m_LoadedCustomCommunities) // TClient: Don't clean filters before custom communities are loaded
 		return;
 	FavoriteCommunitiesFilter().Clean(Communities());
 	CommunitiesFilter().Clean(Communities());

--- a/src/engine/client/serverbrowser.h
+++ b/src/engine/client/serverbrowser.h
@@ -420,6 +420,7 @@ private:
 	static bool ParseCommunityServers(CCommunity *pCommunity, const json_value &Servers);
 
 	// TClient
+	bool m_LoadedCustomCommunities = false;
 	std::function<void(std::vector<json_value *> &)> m_CustomCommunitiesFunction = nullptr;
 	friend class CCustomCommunities;
 };

--- a/src/game/client/components/tclient/custom_communities.cpp
+++ b/src/game/client/components/tclient/custom_communities.cpp
@@ -81,6 +81,10 @@ void CCustomCommunities::LoadCustomCommunitiesDDNetInfo()
 		}
 	};
 	pServerBrowser->LoadDDNetServers();
+
+	if(!pServerBrowser->m_LoadedCustomCommunities)
+		pServerBrowser->CleanFilters();
+	pServerBrowser->m_LoadedCustomCommunities = true;
 }
 
 void CCustomCommunities::OnInit()
@@ -90,9 +94,6 @@ void CCustomCommunities::OnInit()
 
 void CCustomCommunities::OnConsoleInit()
 {
-	// Load Custom Communities from the file before the serverbrowser tries to use it
-	LoadCustomCommunitiesDDNetInfo();
-
 	Console()->Chain(
 		"tc_custom_communities_url", [](IConsole::IResult *pResult, void *pUserData, IConsole::FCommandCallback pfnCallback, void *pCallbackUserData) {
 			pfnCallback(pResult, pCallbackUserData);


### PR DESCRIPTION
https://github.com/TaterClient/TClient/issues/174#issuecomment-3779277866
## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions
- [x] checked checkbox




