### PR TITLE
Mumble fixes

### DIFF
--- a/src/game/client/components/tclient/mumble.cpp
+++ b/src/game/client/components/tclient/mumble.cpp
@@ -73,7 +73,7 @@ void CMumble::OnRender()
 	{
 		char aIdentity[16];
 		str_format(aIdentity, sizeof(aIdentity), "%d", ClientId);
-		if(!mumble_set_context(m_pContext, aIdentity))
+		if(!mumble_set_identity(m_pContext, aIdentity))
 			log_error("mumble", "Failed to set identity");
 		m_LastClientId = ClientId;
 	}


### PR DESCRIPTION
Fixes Mumble plugin, wasn't working before. Also scales the distances so that they are usable for Mumble's defaults.

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [x] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [x] Considered possible null pointers and out of bounds array indexing
- [x] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions